### PR TITLE
Add missing license fields to common and terminal crates

### DIFF
--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -2,6 +2,7 @@
 name = "rad-common"
 version = "0.1.0"
 edition = "2018"
+license = "GPL-3.0-or-later"
 
 [features]
 default = []

--- a/terminal/Cargo.toml
+++ b/terminal/Cargo.toml
@@ -2,6 +2,7 @@
 name = "rad-terminal"
 version = "0.1.0"
 edition = "2018"
+license = "GPL-3.0-or-later"
 
 [dependencies]
 anyhow = "1.0"


### PR DESCRIPTION
`cargo deny check` is complaining about missing license fields on our end:
```
  error[L003]: rad-common = 0.1.0 is unlicensed
  error[L003]: rad-terminal = 0.1.0 is unlicensed
```

https://github.com/radicle-dev/radicle-upstream/runs/5557014675?check_suite_focus=true#step:5:338