### PR TITLE
Add support for WalletConnect in `rad ens`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -615,10 +615,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72feb31ffc86498dacdbd0fcebb56138e7177a8cc5cea4516031d15ae85a742e"
 
 [[package]]
+name = "bytemuck"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e851ca7c24871e7336801608a4797d7376545b6928a10d32d75685687141ead"
+
+[[package]]
 name = "byteorder"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
+
+[[package]]
+name = "bytes"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "206fdffcfa2df7cbe15601ef46c813fce0965eb3286db6b56c583b814b51c81c"
+dependencies = [
+ "byteorder",
+ "iovec",
+]
 
 [[package]]
 name = "bytes"
@@ -723,6 +739,12 @@ dependencies = [
  "poly1305",
  "zeroize",
 ]
+
+[[package]]
+name = "checked_int_cast"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17cc5e6b5ab06331c33589842070416baa137e8b0eb912b008cfd4a78ada7919"
 
 [[package]]
 name = "chunked_transfer"
@@ -895,6 +917,12 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
 ]
+
+[[package]]
+name = "color_quant"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
 
 [[package]]
 name = "colored"
@@ -1296,6 +1324,16 @@ version = "3.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e69600ff1703123957937708eb27f7a564e48885c537782722ed0ba3189ce1d7"
 dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13aea89a5c93364a98e9b37b2fa237effbb694d5cfe01c5b70941f7eb087d5e3"
+dependencies = [
+ "cfg-if 0.1.10",
  "dirs-sys",
 ]
 
@@ -2110,7 +2148,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f45d2795232532958944079ea0c05948b810cd15c5420a3ba4fed9e34f17a864"
 dependencies = [
- "dirs",
+ "dirs 4.0.0",
  "memchr",
  "nom 7.1.0",
 ]
@@ -2859,6 +2897,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "image"
+version = "0.23.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24ffcb7e7244a9bf19d35bf2883b9c080c4ced3c07a9895572178cdb8f13f6a1"
+dependencies = [
+ "bytemuck",
+ "byteorder",
+ "color_quant",
+ "num-iter",
+ "num-rational 0.3.2",
+ "num-traits",
+]
+
+[[package]]
 name = "impl-codec"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3020,6 +3072,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a38fc24e30fd564ce974c02bf1d337caddff65be6cc4735a1f7eab22a7440f04"
 dependencies = [
  "wasm-bindgen",
+]
+
+[[package]]
+name = "jsonrpc-core"
+version = "18.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14f7f76aef2d054868398427f6c54943cf3d1caa9a7ec7d0c38d69df97a965eb"
+dependencies = [
+ "futures",
+ "futures-executor",
+ "futures-util",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
 ]
 
 [[package]]
@@ -3214,7 +3281,7 @@ dependencies = [
  "radicle-macros",
  "radicle-std-ext",
  "rand 0.8.5",
- "rand_pcg",
+ "rand_pcg 0.3.1",
  "regex",
  "rustc-hash",
  "rustls 0.19.1",
@@ -3700,7 +3767,7 @@ dependencies = [
  "blake2b_simd",
  "blake2s_simd",
  "digest 0.9.0",
- "sha-1",
+ "sha-1 0.9.8",
  "sha2 0.9.9",
  "sha3",
  "unsigned-varint 0.5.1",
@@ -3718,7 +3785,7 @@ dependencies = [
  "digest 0.9.0",
  "generic-array 0.14.5",
  "multihash-derive",
- "sha-1",
+ "sha-1 0.9.8",
  "sha2 0.9.9",
  "sha3",
  "unsigned-varint 0.7.1",
@@ -3860,7 +3927,7 @@ dependencies = [
  "num-complex",
  "num-integer",
  "num-iter",
- "num-rational",
+ "num-rational 0.2.4",
  "num-traits",
 ]
 
@@ -3920,6 +3987,17 @@ checksum = "5c000134b5dbf44adc5cb772486d335293351644b801551abe8f75c84cfa4aef"
 dependencies = [
  "autocfg",
  "num-bigint",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12ac428b1cb17fce6f731001d307d351ec70a6d202fc2e60f7d4c5e42d8f4f07"
+dependencies = [
+ "autocfg",
  "num-integer",
  "num-traits",
 ]
@@ -4173,6 +4251,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "phf"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3dfb61232e34fcb633f43d12c58f83c1df82962dcdfa565a4e866ffc17dafe12"
+dependencies = [
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbffee61585b0411840d3ece935cce9cb6321f01c45477d30066498cd5e1a815"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17367f0cc86f2d25802b2c26ee58a7b23faeccf78a396094c13dced0d0182526"
+dependencies = [
+ "phf_shared",
+ "rand 0.7.3",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c00cf8b9eafe68dde5e9eaa2cef8ee84a9336a47d566ec55ca16589633b65af7"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
 name = "picky-asn1"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4393,6 +4509,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "qrcode"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16d2f1455f3630c6e5107b4f2b94e74d76dea80736de0981fd27644216cff57f"
+dependencies = [
+ "checked_int_cast",
+ "image",
+]
+
+[[package]]
 name = "quanta"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4569,6 +4695,7 @@ dependencies = [
  "thiserror",
  "ureq",
  "url",
+ "walletconnect",
 ]
 
 [[package]]
@@ -4935,6 +5062,7 @@ dependencies = [
  "rand_chacha 0.2.2",
  "rand_core 0.5.1",
  "rand_hc",
+ "rand_pcg 0.2.1",
 ]
 
 [[package]]
@@ -5006,6 +5134,15 @@ name = "rand_hc"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
+dependencies = [
+ "rand_core 0.5.1",
+]
+
+[[package]]
+name = "rand_pcg"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16abd0c1b639e9eb4d7c50c0b8100b0d0f849be2349829c740fe8e6eb4816429"
 dependencies = [
  "rand_core 0.5.1",
 ]
@@ -5532,6 +5669,18 @@ dependencies = [
 
 [[package]]
 name = "sha-1"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7d94d0bede923b3cea61f3f1ff57ff8cdfd77b400fb8f9998949e0cf04163df"
+dependencies = [
+ "block-buffer 0.7.3",
+ "digest 0.8.1",
+ "fake-simd",
+ "opaque-debug 0.2.3",
+]
+
+[[package]]
+name = "sha-1"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99cd6713db3cf16b6c84e06321e049a9b9f699826e16096d23bbcc44d15d51a6"
@@ -5650,6 +5799,12 @@ name = "similar"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e24979f63a11545f5f2c60141afe249d4f19f84581ea2138065e400941d83d3"
+
+[[package]]
+name = "siphasher"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bd3e3206899af3f8b12af284fafc038cc1dc2b41d1b89dd17297221c5d225de"
 
 [[package]]
 name = "sized-chunks"
@@ -5863,6 +6018,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "termcolor"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "terminal_size"
 version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5870,6 +6034,19 @@ checksum = "633c1a546cee861a1a6d0dc69ebeca693bf4296661ba7852b9d21d159e0506df"
 dependencies = [
  "libc",
  "winapi 0.3.9",
+]
+
+[[package]]
+name = "terminfo"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76971977e6121664ec1b960d1313aacfa75642adc93b9d4d53b247bd4cb1747e"
+dependencies = [
+ "dirs 2.0.2",
+ "fnv",
+ "nom 5.1.2",
+ "phf",
+ "phf_codegen",
 ]
 
 [[package]]
@@ -6281,6 +6458,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "walletconnect"
+version = "0.1.0"
+source = "git+https://github.com/xphoniex/walletconnect-rs?branch=v0.1.0#82ab29227318b03254203d9cae62ea9ab9630d06"
+dependencies = [
+ "atty",
+ "data-encoding",
+ "ethers-core",
+ "futures",
+ "jsonrpc-core",
+ "lazy_static",
+ "log",
+ "openssl",
+ "qrcode",
+ "rand 0.8.5",
+ "ring",
+ "serde",
+ "serde_json",
+ "termcolor",
+ "terminfo",
+ "thiserror",
+ "url",
+ "uuid",
+ "ws",
+ "zeroize",
+]
+
+[[package]]
 name = "want"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6524,6 +6728,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0120db82e8a1e0b9fb3345a539c478767c0048d842860994d96113d5b667bd69"
 dependencies = [
  "winapi 0.3.9",
+]
+
+[[package]]
+name = "ws"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25fe90c75f236a0a00247d5900226aea4f2d7b05ccc34da9e7a8880ff59b5848"
+dependencies = [
+ "byteorder",
+ "bytes 0.4.12",
+ "httparse",
+ "log",
+ "mio 0.6.23",
+ "mio-extras",
+ "openssl",
+ "rand 0.7.3",
+ "sha-1 0.8.2",
+ "slab",
+ "url",
 ]
 
 [[package]]

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -6,7 +6,7 @@ license = "GPL-3.0-or-later"
 
 [features]
 default = []
-ethereum = ["ethers", "coins-bip32", "async-trait", "hex"]
+ethereum = ["ethers", "coins-bip32", "async-trait", "hex", "walletconnect"]
 
 [dependencies]
 anyhow = "1.0"
@@ -48,4 +48,10 @@ optional = true
 
 [dependencies.hex]
 version = "0.4.3"
+optional = true
+
+[dependencies.walletconnect]
+git = "https://github.com/xphoniex/walletconnect-rs"
+branch = "v0.1.0"
+features = ["qr"]
 optional = true

--- a/common/src/ethereum/walletconnect.rs
+++ b/common/src/ethereum/walletconnect.rs
@@ -1,0 +1,104 @@
+use std::error::Error;
+use walletconnect::client::{CallError, SessionError};
+use walletconnect::{qr, Client, Metadata, Transaction};
+
+use ethers::types::transaction::eip2718::TypedTransaction;
+use ethers::types::{Address, NameOrAddress, Signature, U256};
+
+#[derive(Debug)]
+pub struct WalletConnect {
+    client: Client,
+    chain_id: u64,
+    address: Address,
+}
+
+impl WalletConnect {
+    pub fn new() -> Result<Self, Box<dyn Error>> {
+        let client = Client::new(
+            "radicle-cli",
+            Metadata {
+                description: "Interact with Radicle".into(),
+                url: "https://radicle.network".parse()?,
+                icons: vec!["https://app.radicle.network/logo.png".parse()?],
+                name: "Radicle CLI".into(),
+            },
+        )?;
+
+        Ok(WalletConnect {
+            client,
+            chain_id: 0,
+            address: Address::zero(),
+        })
+    }
+
+    pub async fn show_qr(mut self) -> Result<Self, SessionError> {
+        let (accounts, chain_id) = self
+            .client
+            .ensure_session(|uri| {
+                println!("{}", uri.as_url());
+                qr::print(uri);
+            })
+            .await?;
+
+        self.chain_id = chain_id;
+        self.address.assign_from_slice(accounts[0].as_bytes());
+
+        Ok(self)
+    }
+
+    pub fn chain_id(&self) -> u64 {
+        self.chain_id
+    }
+
+    pub fn address(&self) -> Address {
+        self.address
+    }
+
+    fn address_string(&self) -> String {
+        format!("{}", self.address)
+    }
+
+    pub async fn sign_message<S: Send + Sync + AsRef<[u8]>>(
+        &self,
+        msg: S,
+    ) -> Result<Signature, CallError> {
+        let msg = unsafe { std::str::from_utf8_unchecked(msg.as_ref()) };
+        self.client
+            .personal_sign(&[msg, &self.address_string()])
+            .await
+    }
+
+    pub async fn sign_transaction(&self, msg: &TypedTransaction) -> Result<Signature, CallError> {
+        let to = if let Some(NameOrAddress::Address(address)) = msg.to() {
+            Some(*address)
+        } else {
+            None
+        };
+        let tx = Transaction {
+            from: *msg.from().unwrap(),
+            to,
+            gas_limit: None,
+            gas_price: msg.gas_price(),
+            value: *msg.value().unwrap_or(&U256::from(0)),
+            data: msg.data().unwrap().to_vec(),
+            nonce: msg.nonce().copied(),
+        };
+
+        let raw = self.client.sign_transaction(tx).await?.to_vec();
+        assert_eq!(raw[raw.len() - 66], 160);
+        assert_eq!(raw[raw.len() - 33], 160);
+
+        // Transform `v` according to:
+        // https://github.com/ethereum/EIPs/blob/master/EIPS/eip-155.md#specification
+        let mut v = raw[raw.len() - 67] as u64;
+        if v == 27 || v == 28 {
+            v += 2 * self.chain_id() + 8;
+        }
+
+        Ok(Signature {
+            v,
+            r: U256::from(&raw[raw.len() - 65..raw.len() - 33]),
+            s: U256::from(&raw[raw.len() - 32..]),
+        })
+    }
+}

--- a/ens/src/lib.rs
+++ b/ens/src/lib.rs
@@ -285,7 +285,7 @@ async fn setup(
         }
     }
 
-    let call = resolver.multicall(calls)?;
+    let call = resolver.multicall(calls)?.gas(21000);
     ethereum::transaction(call).await?;
 
     let spinner = term::spinner("Updating local identity...");

--- a/ens/src/lib.rs
+++ b/ens/src/lib.rs
@@ -25,6 +25,7 @@ Usage
     rad ens               [<option>...]
     rad ens --setup       [<option>...] [--rpc-url <url>] --ledger-hdpath <hd-path>
     rad ens --setup       [<option>...] [--rpc-url <url>] --keystore <file>
+    rad ens --setup       [<option>...] [--rpc-url <url>] --walletconnect
     rad ens [<operation>] [<option>...]
 
     If no operation is specified, `--show` is implied.
@@ -44,6 +45,7 @@ Wallet options
     --rpc-url <url>              JSON-RPC URL of Ethereum node (eg. http://localhost:8545)
     --ledger-hdpath <hdpath>     Account derivation path when using a Ledger hardware device
     --keystore <file>            Keystore file containing encrypted private key (default: none)
+    --walletconnect              Use WalletConnect
 
 Environment variables
 


### PR DESCRIPTION
Currently in `Cargo.toml` it's using:

```
walletconnect = { git = "https://github.com/xphoniex/walletconnect-rs", branch = "v0.1.0", features = ["qr"] }`. 
```

which is in my own personal github. Might be helpful to move this to `radicle-dev`, before merging. I changed the types in original package and since author is not responsive, not sure we can merge it in.