### PR TITLE
Remove openssl-sys dependency from rad-common

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2540,8 +2540,6 @@ dependencies = [
  "libc",
  "libgit2-sys",
  "log",
- "openssl-probe",
- "openssl-sys",
  "url",
 ]
 
@@ -3148,9 +3146,7 @@ checksum = "19e1c899248e606fbfe68dcb31d8b0176ebab833b103824af31bddf4b7457494"
 dependencies = [
  "cc",
  "libc",
- "libssh2-sys",
  "libz-sys",
- "openssl-sys",
  "pkg-config",
 ]
 
@@ -3233,20 +3229,6 @@ dependencies = [
  "uuid",
  "webpki 0.21.4",
  "xorf",
-]
-
-[[package]]
-name = "libssh2-sys"
-version = "0.2.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b094a36eb4b8b8c8a7b4b8ae43b2944502be3e59cd87687595cf6b0a71b3f4ca"
-dependencies = [
- "cc",
- "libc",
- "libz-sys",
- "openssl-sys",
- "pkg-config",
- "vcpkg",
 ]
 
 [[package]]

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -14,7 +14,7 @@ base64 = "0.13"
 byteorder = "1.4"
 either = { version = "1.6" }
 git-repository = "0.14"
-git2 = "0.13"
+git2 = { version = "0.13", default-features = false }
 lazy_static = "1.4.0"
 serde_json = "1.0"
 serde = "1.0"


### PR DESCRIPTION
We remove the transitive `openssl-sys` from `rad-common` so that binaries using this crate don’t link against `openssl` since this creates problems on macOS.