### PR TITLE
rad-auth: handle empty and non-active profiles

### DIFF
--- a/auth/src/lib.rs
+++ b/auth/src/lib.rs
@@ -189,7 +189,7 @@ pub fn authenticate(profiles: &[profile::Profile], options: Options) -> anyhow::
     }
 
     let selection = if profiles.len() > 1 && !options.active {
-        if let Some(p) = term::format::profile_select(profiles, &profile) {
+        if let Some(p) = term::format::profile::select(profiles, &profile) {
             p
         } else {
             return Ok(());

--- a/auth/src/lib.rs
+++ b/auth/src/lib.rs
@@ -108,7 +108,8 @@ pub fn run(options: Options) -> anyhow::Result<()> {
     if options.init || profiles.is_empty() || ignore_empty {
         init(options)
     } else {
-        authenticate(&profiles, options)
+        let profile = profile::default()?;
+        authenticate(&profiles, &profile, options)
     }
 }
 
@@ -178,9 +179,12 @@ pub fn init(options: Options) -> anyhow::Result<()> {
     Ok(())
 }
 
-pub fn authenticate(profiles: &[profile::Profile], options: Options) -> anyhow::Result<()> {
+pub fn authenticate(
+    profiles: &[profile::Profile],
+    profile: &profile::Profile,
+    options: Options,
+) -> anyhow::Result<()> {
     let sock = keys::ssh_auth_sock();
-    let profile = profile::default()?;
 
     if !options.active {
         term::info!(
@@ -190,13 +194,13 @@ pub fn authenticate(profiles: &[profile::Profile], options: Options) -> anyhow::
     }
 
     let selection = if profiles.len() > 1 && !options.active {
-        if let Some(p) = term::format::profile::select(profiles, &profile) {
+        if let Some(p) = term::format::profile::select(profiles, profile) {
             p
         } else {
             return Ok(());
         }
     } else {
-        &profile
+        profile
     };
 
     let read_only = profile::read_only(selection)?;

--- a/auth/src/lib.rs
+++ b/auth/src/lib.rs
@@ -101,12 +101,11 @@ impl Args for Options {
 }
 
 pub fn run(options: Options) -> anyhow::Result<()> {
-    let profiles = match profile::list() {
-        Ok(profiles) => profiles,
-        _ => vec![],
-    };
+    let profiles = selectable_profiles();
+    let ignored = ignored_profiles();
+    let ignore_empty = profiles.is_empty() && !ignored.is_empty();
 
-    if options.init || profiles.is_empty() {
+    if options.init || profiles.is_empty() || ignore_empty {
         init(options)
     } else {
         authenticate(&profiles, options)
@@ -256,6 +255,10 @@ pub fn check_ignored() -> anyhow::Result<()> {
     }
 
     Ok(())
+}
+
+pub fn selectable_profiles() -> Vec<profile::Profile> {
+    filtered_profiles(|p| profile::read_only(p).is_ok())
 }
 
 pub fn ignored_profiles() -> Vec<profile::Profile> {

--- a/terminal/src/lib.rs
+++ b/terminal/src/lib.rs
@@ -581,18 +581,19 @@ pub mod components {
             }
         }
 
-        pub fn profile_select<'a>(
-            profiles: &'a [Profile],
-            active: &Profile,
-        ) -> Option<&'a Profile> {
-            let active = profiles.iter().position(|p| p.id() == active.id()).unwrap();
-            let selection = dialoguer::Select::with_theme(&theme())
-                .items(&profiles.iter().map(|p| p.id()).collect::<Vec<_>>())
-                .default(active)
-                .interact_opt()
-                .unwrap();
+        pub mod profile {
 
-            selection.map(|i| &profiles[i])
+            use super::{theme, Profile};
+
+            pub fn select<'a>(profiles: &'a [Profile], active: &Profile) -> Option<&'a Profile> {
+                let active = profiles.iter().position(|p| p.id() == active.id()).unwrap();
+                let selection = dialoguer::Select::with_theme(&theme())
+                    .items(&profiles.iter().map(|p| p.id()).collect::<Vec<_>>())
+                    .default(active)
+                    .interact_opt()
+                    .unwrap();
+                selection.map(|i| &profiles[i])
+            }
         }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/radicle-dev/radicle-cli/issues/77.
Fixes https://github.com/radicle-dev/radicle-cli/issues/72.

This PR changes the `rad auth` behaviour such that it handles empty (non readable monorepo) and non-active profiles:
- if empty profile(s) exists (e.g. the one created by `upstream-proxy`), these
  - a) issue a warning
  - b) are ignored when creating a new profile and identity
  - c) won't show up in profile selection anymore
- if a non-empty profile exists, but no active profile was found (deleted `active_profile` file), user can activate a fallback profile (first in the list)