### PR TITLE
rad-auth: Handle non-active existing profile(s)

### DIFF
--- a/auth/src/lib.rs
+++ b/auth/src/lib.rs
@@ -105,8 +105,12 @@ pub fn run(options: Options) -> anyhow::Result<()> {
         Ok(profiles) => profiles,
         _ => vec![],
     };
+    let initialized = !profiles.is_empty() && profile::default().is_ok();
 
-    if options.init || profiles.is_empty() {
+    if options.init || profiles.is_empty() || !initialized {
+        if !initialized {
+            term::warning("Found profile(s) but could not load active one. Initializing...");
+        }
         init(options)
     } else {
         authenticate(&profiles, options)

--- a/common/src/profile.rs
+++ b/common/src/profile.rs
@@ -11,13 +11,19 @@ pub fn default() -> Result<Profile, Error> {
     use rad_terminal::args;
 
     let error = args::Error::WithHint {
-        err: anyhow!("failed to load radicle profile"),
+        err: anyhow!("Could not load radicle profile"),
         hint: "To setup your radicle profile, run `rad auth`.",
+    };
+
+    let not_active_error = args::Error::WithHint {
+        err: anyhow!("Could not load active radicle profile"),
+        hint: "To setup your radicle profile, run `rad auth --init`.",
     };
 
     match lnk_profile::get(None, None) {
         Ok(Some(profile)) => Ok(profile),
-        Ok(None) | Err(_) => Err(error.into()),
+        Ok(None) => Err(not_active_error.into()),
+        Err(_) => Err(error.into()),
     }
 }
 


### PR DESCRIPTION
Fixes https://github.com/radicle-dev/radicle-cli/issues/77.
Fixes https://github.com/radicle-dev/radicle-cli/issues/72.