### PR TITLE
Allow for piping password to rad-auth

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4756,11 +4756,13 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "assay",
+ "atty",
  "lexopt",
  "librad",
  "lnk-profile",
  "rad-common",
  "rad-terminal",
+ "zeroize",
 ]
 
 [[package]]

--- a/auth/Cargo.toml
+++ b/auth/Cargo.toml
@@ -13,6 +13,8 @@ librad = "0"
 lnk-profile = "0"
 rad-terminal = { path = "../terminal" }
 rad-common = { path = "../common" }
+atty = "0.2"
+zeroize = "1.1"
 
 [dev-dependencies]
 assay = "0.1.0"


### PR DESCRIPTION
Allows doing this, for easier password input:

```
pass radicle/auth | rad-auth
```

where `pass` is https://www.passwordstore.org/ or a similar command line-accessible password manager.