### PR TITLE
Fix missing shared libraries problem on M1 Macs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,7 +104,7 @@ jobs:
         with:
           profile: minimal
       - name: Build the release binaries
-        run: cargo build --release
+        run: env OPENSSL_STATIC=1 OPENSSL_DIR=/usr/local/opt/openssl@1.1 LIBUSB_STATIC=1 cargo build --release
       - name: Build the release archive
         shell: bash
         run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3431,8 +3431,7 @@ dependencies = [
 [[package]]
 name = "libusb1-sys"
 version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6dfab089105aa85a3b492b421bd90d55e6257f00f8447cc3873c44f8206809ce"
+source = "git+https://github.com/radicle-dev/rusb.git?rev=b58761e7961efab082aea6d22a58a199dc687c5e#b58761e7961efab082aea6d22a58a199dc687c5e"
 dependencies = [
  "cc",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -164,3 +164,7 @@ rev = "a9485b78b5c78d252c92f61d990cf34622d1c8f1"
 [patch.crates-io.automerge]
 git = "https://github.com/automerge/automerge-rs"
 rev = "291557a019acac283e54ea31a9fad81ed65736ab"
+
+[patch.crates-io.libusb1-sys]
+git = "https://github.com/radicle-dev/rusb.git"
+rev = "b58761e7961efab082aea6d22a58a199dc687c5e"


### PR DESCRIPTION
Fix missing shared libraries problem on M1 Macs: libssl and libusb.

~~A workaround in libusb-sys has been implemented.  The bug is yet to be reported upstream to libusb.  It's to do with missing libobj.a static library on new versions of macOS.  libusb pkg-config .pc file seems to be assuming they're still there.~~

~~Once the issue is resolved upstream, the workaround in libusb-sys will be removed.~~

According to my understanding, the static build of libusb1-sys on macOS fails because of [a bug in rustc](https://github.com/rust-lang/rust/issues/96943).

IMO, it's best if we maintain a version of libusb1-sys with a workaround (referenced in this PR via `patch.io-crates`) until a rustc fix gets released.