### PR TITLE
common: Add ENS name to PeerIdentity and PeerInfo

### DIFF
--- a/common/src/person.rs
+++ b/common/src/person.rs
@@ -23,7 +23,7 @@ lazy_static::lazy_static! {
 }
 
 /// ENS payload.
-#[derive(Debug, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct Ens {
     pub name: String,
 }


### PR DESCRIPTION
This PR tries to resolve from the `person.payload()` the `Ens` extension and adds it to the `PeerIdentity` and `PeerInfo`
We need this PR to merge for the issue listing, where we want to resolve a ENS name from a Radicle URN.