### PR TITLE
common: Serialize char keys in Comment::reactions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 /target
 /tmp
 errors.err
+
+# MacOS
+.DS_Store

--- a/common/src/cobs/shared.rs
+++ b/common/src/cobs/shared.rs
@@ -26,6 +26,7 @@ pub enum ResolveError {
 pub type Discussion = Vec<Comment<Replies>>;
 
 #[derive(Debug, PartialEq, Eq, Hash, Copy, Clone, Serialize, Deserialize)]
+#[serde(transparent)]
 pub struct Reaction {
     pub emoji: char,
 }


### PR DESCRIPTION
This commit introduces the `serialize_reactions` function which is being
used in the `reactions` field in the `Comment` struct.

To be able to convert `Comment` struct to JSON and return them e.g. in
the http-api we need to convert the
`char` into `String` during serialization.

Signed-off-by: Sebastian Martinez <sebastinez@me.com>