### PR TITLE
rad-issue: Add `rad issue reaction`

### DIFF
--- a/issue/src/lib.rs
+++ b/issue/src/lib.rs
@@ -21,6 +21,8 @@ Usage
 
     rad issue create [--title <title>] [--description <text>]
     rad issue remove <id>
+    rad issue comment <id> [--description <text>]
+    rad issue react <id> [--emoji <char>]
     rad issue list
 
 Options

--- a/terminal/src/io.rs
+++ b/terminal/src/io.rs
@@ -7,6 +7,8 @@ use librad::profile::Profile;
 
 use dialoguer::{console::style, console::Style, theme::ColorfulTheme, Input, Password};
 
+use radicle_common::cobs::issue::Issue;
+use radicle_common::cobs::shared::CommentId;
 use radicle_common::signer::ToSigner;
 
 use super::command;
@@ -323,6 +325,24 @@ pub fn profile_select<'a>(profiles: &'a [Profile], active: &Profile) -> Option<&
         .unwrap();
 
     selection.map(|i| &profiles[i])
+}
+
+pub fn comment_select(issue: &Issue) -> Option<CommentId> {
+    let selection = dialoguer::Select::with_theme(&theme())
+        .with_prompt("Which comment do you want to react to?")
+        .item(&issue.description().to_string())
+        .items(
+            &issue
+                .comments()
+                .iter()
+                .map(|p| p.body.clone())
+                .collect::<Vec<_>>(),
+        )
+        .default(CommentId::root().into())
+        .interact_opt()
+        .unwrap();
+
+    selection.map(CommentId::from)
 }
 
 pub fn markdown(content: &str) {


### PR DESCRIPTION
Allows adding emoji reactions as string to a comment specified by its number,
being 0 the root comment.

**TODO:**
- [x] Improve the way to select a comment to which react, eventually a selectable comment listing