### PR TITLE
rad-auth: Add warning for when `ssh-agent` is not running

### DIFF
--- a/auth/src/lib.rs
+++ b/auth/src/lib.rs
@@ -266,7 +266,10 @@ pub fn authenticate(
         } else {
             term::success!("Signing key already in ssh-agent");
         }
-    }
+    } else {
+        term::warning("Radicle key won't be added to ssh-agent since it's not running.");
+        term::blank();
+    };
 
     Ok(())
 }


### PR DESCRIPTION
Running `rad auth` when no ssh-agent exists succeeds and when you run any other `rad` command you'll be asked to re-enter password. This is confusing and a warning would be helpful when running `auth`.