### PR TITLE
common: Reduce nesting in `Author.identity`

### DIFF
--- a/common/src/cobs/issue.rs
+++ b/common/src/cobs/issue.rs
@@ -862,13 +862,13 @@ mod test {
         let c1 = &issue.comments()[0];
 
         assert!(
-            matches!(&issue.author().identity, Identity::Resolved { identity } if identity.name == "cloudhead")
+            matches!(&issue.author().identity, Identity::Resolved { name, .. } if name == "cloudhead")
         );
         assert!(
-            matches!(&issue.comment.author.identity, Identity::Resolved { identity } if identity.name == "cloudhead")
+            matches!(&issue.comment.author.identity, Identity::Resolved { name, .. } if name == "cloudhead")
         );
         assert!(
-            matches!(&c1.author.identity, Identity::Resolved { identity } if identity.name == "cloudhead")
+            matches!(&c1.author.identity, Identity::Resolved { name, .. } if name == "cloudhead")
         );
     }
 


### PR DESCRIPTION
This commit reduces a resolved identity from:

```json
"author": {
  "peer": "hybepksbf5xzew3ztear7k7peddho5wfts3d8uyb9pcdu6sqgnwqak",
  "identity": {
    "identity": {
      "urn": "rad:git:hnrkkxqo5jgx3bwbphdsmqyk9djkfr368czio",
      "name": "Scooby",
      "ens": null
    }
  }
}
```

to

```json
"author": {
  "peer": "hybepksbf5xzew3ztear7k7peddho5wfts3d8uyb9pcdu6sqgnwqak",
  "identity": {
    "urn": "rad:git:hnrkkxqo5jgx3bwbphdsmqyk9djkfr368czio",
    "name": "Scooby",
    "ens": null
  }
}
```

A unresolved identity, stays like
`{ "identity": { "urn": "rad:git:<project URN>" } }`

Signed-off-by: Sebastian Martinez <me@sebastinez.dev>