### PR TITLE
terminal: TUI library

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5204,6 +5204,7 @@ dependencies = [
  "librad",
  "lnk-profile",
  "radicle-common",
+ "textwrap",
  "thiserror",
  "tui",
  "zeroize",
@@ -6019,6 +6020,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2dd574626839106c320a323308629dcb1acfc96e32a8cba364ddc61ac23ee83"
 
 [[package]]
+name = "smawk"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f67ad224767faa3c7d8b6d91985b78e70a1324408abcb1cfcc2be4c06bc06043"
+
+[[package]]
 name = "smol_str"
 version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6198,6 +6205,11 @@ name = "textwrap"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
+dependencies = [
+ "smawk",
+ "unicode-linebreak",
+ "unicode-width",
+]
 
 [[package]]
 name = "thiserror"
@@ -6450,6 +6462,15 @@ name = "unicode-bidi"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "099b7128301d285f79ddd55b9a83d5e6b9e97c92e0ea0daebee7263e932de992"
+
+[[package]]
+name = "unicode-linebreak"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a52dcaab0c48d931f7cc8ef826fa51690a08e1ea55117ef26f89864f532383f"
+dependencies = [
+ "regex",
+]
 
 [[package]]
 name = "unicode-normalization"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -744,6 +744,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cassowary"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
+
+[[package]]
 name = "cc"
 version = "1.0.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1194,6 +1200,31 @@ checksum = "0bf124c720b7686e3c2663cf54062ab0f68a88af2fb6a030e87e30bf721fcb38"
 dependencies = [
  "cfg-if 1.0.0",
  "lazy_static",
+]
+
+[[package]]
+name = "crossterm"
+version = "0.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2102ea4f781910f8a5b98dd061f4c2023f479ce7bb1236330099ceb5a93cf17"
+dependencies = [
+ "bitflags",
+ "crossterm_winapi",
+ "libc",
+ "mio 0.8.2",
+ "parking_lot 0.12.0",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ae1b35a484aa10e07fe0638d02301c5ad24de82d310ccbd2f3693da5f09bf1c"
+dependencies = [
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -5165,13 +5196,16 @@ dependencies = [
  "anyhow",
  "async-trait",
  "console",
+ "crossterm",
  "dialoguer",
  "indicatif",
+ "lazy_static",
  "lexopt",
  "librad",
  "lnk-profile",
  "radicle-common",
  "thiserror",
+ "tui",
  "zeroize",
 ]
 
@@ -5912,6 +5946,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "signal-hook-mio"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29ad2e15f37ec9a6cc544097b78a1ec90001e9f71b81338ca39f430adaca99af"
+dependencies = [
+ "libc",
+ "mio 0.8.2",
+ "signal-hook",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6359,6 +6404,19 @@ name = "try-lock"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
+
+[[package]]
+name = "tui"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96fe69244ec2af261bced1d9046a6fee6c8c2a6b0228e59e5ba39bc8ba4ed729"
+dependencies = [
+ "bitflags",
+ "cassowary",
+ "crossterm",
+ "unicode-segmentation",
+ "unicode-width",
+]
 
 [[package]]
 name = "typenum"

--- a/terminal/Cargo.toml
+++ b/terminal/Cargo.toml
@@ -14,10 +14,12 @@ anyhow = "1.0"
 dialoguer = "0.10.0"
 indicatif = "0.16.2"
 console = "0.15"
+crossterm = { version = "0.23" }
 lexopt = "0.2.0"
 librad = { version = "0" }
 lnk-profile = { version = "0" }
 thiserror = "1.0"
+tui = { version = "0.18.0" }
 zeroize = "1.1"
 
 [dependencies.radicle-common]

--- a/terminal/Cargo.toml
+++ b/terminal/Cargo.toml
@@ -21,6 +21,7 @@ librad = { version = "0" }
 lnk-profile = { version = "0" }
 thiserror = "1.0"
 tui = { version = "0.18.0" }
+textwrap = {version = "0.15.0" }
 zeroize = "1.1"
 
 [dependencies.radicle-common]

--- a/terminal/Cargo.toml
+++ b/terminal/Cargo.toml
@@ -16,6 +16,7 @@ indicatif = "0.16.2"
 console = "0.15"
 crossterm = { version = "0.23" }
 lexopt = "0.2.0"
+lazy_static = { version = "1.4.0" }
 librad = { version = "0" }
 lnk-profile = { version = "0" }
 thiserror = "1.0"

--- a/terminal/examples/tui.rs
+++ b/terminal/examples/tui.rs
@@ -1,22 +1,40 @@
+use std::collections::HashMap;
+
 use anyhow::{Error, Result};
+use lazy_static::lazy_static;
 
 use radicle_terminal::tui::events::{InputEvent, Key};
 use radicle_terminal::tui::store::Store;
 use radicle_terminal::tui::{Application, State};
 
+#[derive(Clone, Eq, PartialEq)]
+pub enum Action {
+    Quit,
+}
+
+lazy_static! {
+    static ref KEY_BINDINGS: HashMap<Key, Action> =
+        [(Key::Char('q'), Action::Quit)].iter().cloned().collect();
+}
+
 fn main() -> Result<(), Error> {
     // Create basic application that will call `update` on
     // every input event received from event thread.
-    let mut application = Application::new(&update);
+    let mut application = Application::new(&on_action);
     application.execute()?;
     Ok(())
 }
 
-fn update(store: &mut Store, event: &InputEvent) -> anyhow::Result<(), anyhow::Error> {
+fn on_action(store: &mut Store, event: &InputEvent) -> anyhow::Result<(), anyhow::Error> {
     // Set application set to `State::Exiting` when the key 'q' is received.
     // Note that any special tick handling is ignored for now.
-    if let InputEvent::Input(Key::Char('q')) = *event {
-        store.set("app.state", Box::new(State::Exiting));
+    if let InputEvent::Input(key) = *event {
+        if let Some(action) = KEY_BINDINGS.get(&key) {
+            match action {
+                Action::Quit => store.set("app.state", Box::new(State::Exiting)),
+            }
+        }
     }
+    
     Ok(())
 }

--- a/terminal/examples/tui.rs
+++ b/terminal/examples/tui.rs
@@ -21,7 +21,10 @@ lazy_static! {
 fn main() -> Result<(), Error> {
     // Create basic application that will call `update` on
     // every input event received from event thread.
-    let mut application = Application::new(&on_action);
+    let mut application = Application::new(&on_action).store(vec![(
+        "app.shortcuts",
+        Box::new(vec![String::from("q quit")]),
+    )]);
     let theme = Theme::default_dark();
     application.execute(&theme)?;
     Ok(())

--- a/terminal/examples/tui.rs
+++ b/terminal/examples/tui.rs
@@ -1,0 +1,22 @@
+use anyhow::{Error, Result};
+
+use radicle_terminal::tui::events::{InputEvent, Key};
+use radicle_terminal::tui::store::Store;
+use radicle_terminal::tui::{Application, State};
+
+fn main() -> Result<(), Error> {
+    // Create basic application that will call `update` on
+    // every input event received from event thread.
+    let mut application = Application::new(&update);
+    application.execute()?;
+    Ok(())
+}
+
+fn update(store: &mut Store, event: &InputEvent) -> anyhow::Result<(), anyhow::Error> {
+    // Set application set to `State::Exiting` when the key 'q' is received.
+    // Note that any special tick handling is ignored for now.
+    if let InputEvent::Input(Key::Char('q')) = *event {
+        store.set("app.state", Box::new(State::Exiting));
+    }
+    Ok(())
+}

--- a/terminal/examples/tui.rs
+++ b/terminal/examples/tui.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::rc::Rc;
 
 use anyhow::{Error, Result};
 use lazy_static::lazy_static;
@@ -6,6 +7,7 @@ use lazy_static::lazy_static;
 use radicle_terminal::tui::events::{InputEvent, Key};
 use radicle_terminal::tui::store::Store;
 use radicle_terminal::tui::theme::Theme;
+use radicle_terminal::tui::window::{EmptyWidget, PageWidget, ShortcutWidget, TitleWidget};
 use radicle_terminal::tui::{Application, State};
 
 #[derive(Clone, Eq, PartialEq)]
@@ -25,8 +27,19 @@ fn main() -> Result<(), Error> {
         ("app.shortcuts", Box::new(vec![String::from("q quit")])),
         ("app.title", Box::new(String::from("tui-example"))),
     ]);
+
+    // Create a single-page application
+    let pages = vec![PageWidget {
+        title: Rc::new(TitleWidget),
+        widgets: vec![Rc::new(EmptyWidget)],
+        shortcuts: Rc::new(ShortcutWidget),
+    }];
+
+    // Use default, borderless theme
     let theme = Theme::default_dark();
-    application.execute(&theme)?;
+
+    // Run application
+    application.execute(pages, &theme)?;
     Ok(())
 }
 

--- a/terminal/examples/tui.rs
+++ b/terminal/examples/tui.rs
@@ -21,10 +21,10 @@ lazy_static! {
 fn main() -> Result<(), Error> {
     // Create basic application that will call `update` on
     // every input event received from event thread.
-    let mut application = Application::new(&on_action).store(vec![(
-        "app.shortcuts",
-        Box::new(vec![String::from("q quit")]),
-    )]);
+    let mut application = Application::new(&on_action).store(vec![
+        ("app.shortcuts", Box::new(vec![String::from("q quit")])),
+        ("app.title", Box::new(String::from("tui-example"))),
+    ]);
     let theme = Theme::default_dark();
     application.execute(&theme)?;
     Ok(())

--- a/terminal/examples/tui.rs
+++ b/terminal/examples/tui.rs
@@ -5,6 +5,7 @@ use lazy_static::lazy_static;
 
 use radicle_terminal::tui::events::{InputEvent, Key};
 use radicle_terminal::tui::store::Store;
+use radicle_terminal::tui::theme::Theme;
 use radicle_terminal::tui::{Application, State};
 
 #[derive(Clone, Eq, PartialEq)]
@@ -21,7 +22,8 @@ fn main() -> Result<(), Error> {
     // Create basic application that will call `update` on
     // every input event received from event thread.
     let mut application = Application::new(&on_action);
-    application.execute()?;
+    let theme = Theme::default_dark();
+    application.execute(&theme)?;
     Ok(())
 }
 
@@ -35,6 +37,5 @@ fn on_action(store: &mut Store, event: &InputEvent) -> anyhow::Result<(), anyhow
             }
         }
     }
-    
     Ok(())
 }

--- a/terminal/examples/tui_internal_call.rs
+++ b/terminal/examples/tui_internal_call.rs
@@ -1,0 +1,117 @@
+use std::collections::HashMap;
+use std::rc::Rc;
+use std::thread;
+use std::time::Duration;
+
+use anyhow::{Error, Result};
+use lazy_static::lazy_static;
+
+use radicle_terminal as term;
+
+use term::tui::events::{InputEvent, Key};
+use term::tui::store::Store;
+use term::tui::theme::Theme;
+use term::tui::window::{EmptyWidget, PageWidget, ShortcutWidget, TitleWidget};
+use term::tui::{Application, State};
+
+#[derive(Clone, Eq, PartialEq)]
+pub enum Action {
+    Quit,
+    Command,
+}
+
+#[derive(Clone, Eq, PartialEq)]
+pub enum InternalCall {
+    Echo(String),
+}
+
+lazy_static! {
+    static ref KEY_BINDINGS: HashMap<Key, Action> = [
+        (Key::Char('q'), Action::Quit),
+        (Key::Char('c'), Action::Command)
+    ]
+    .iter()
+    .cloned()
+    .collect();
+}
+
+fn main() -> Result<(), Error> {
+    // Run application, execute logic and re-run until no internal call
+    // is returned by application.
+    while let Some(call) = run()? {
+        match call {
+            InternalCall::Echo(message) => {
+                println!(
+                    "Message: {}, sleeping for 5 seconds and re-running application",
+                    message
+                );
+                thread::sleep(Duration::from_secs(5));
+            }
+        }
+    }
+    Ok(())
+}
+
+fn run() -> Result<Option<InternalCall>, Error> {
+    // Create basic application that will call `update` on
+    // every input event received from event thread.
+    let call: Option<InternalCall> = None;
+    let mut application = Application::new(&on_action).store(vec![
+        (
+            "app.shortcuts",
+            Box::new(vec![String::from("q quit"), String::from("c command")]),
+        ),
+        ("app.title", Box::new(String::from("tui-internal-call"))),
+        ("app.call.internal", Box::new(call)),
+    ]);
+
+    // Create a single-page application
+    let pages = vec![PageWidget {
+        title: Rc::new(TitleWidget),
+        widgets: vec![Rc::new(EmptyWidget)],
+        shortcuts: Rc::new(ShortcutWidget),
+    }];
+
+    // Use default, borderless theme
+    let theme = Theme::default_dark();
+
+    // Run application
+    application.execute(pages, &theme)?;
+
+    // If application set an interal call, return it to signal that it should
+    // be executed and application re-run after
+    match application
+        .store
+        .get::<Option<InternalCall>>("app.call.internal")
+    {
+        Ok(Some(call)) => return Ok(Some(call.clone())),
+        Ok(None) | Err(_) => return Ok(None),
+    }
+}
+
+fn on_action(store: &mut Store, event: &InputEvent) -> anyhow::Result<(), anyhow::Error> {
+    // Set application set to `State::Exiting` when the key 'q' is received.
+    // Note that any special tick handling is ignored for now.
+    if let InputEvent::Input(key) = *event {
+        if let Some(action) = KEY_BINDINGS.get(&key) {
+            match action {
+                Action::Quit => quit(store),
+                Action::Command => run_command(store),
+            }
+        }
+    }
+    Ok(())
+}
+
+fn quit(store: &mut Store) {
+    store.set("app.state", Box::new(State::Exiting))
+}
+
+fn run_command(store: &mut Store) {
+    let message = String::from("tui-internal-call");
+    store.set(
+        "app.call.internal",
+        Box::new(Some(InternalCall::Echo(message))),
+    );
+    store.set("app.state", Box::new(State::Exiting))
+}

--- a/terminal/src/lib.rs
+++ b/terminal/src/lib.rs
@@ -11,6 +11,7 @@ pub mod spinner;
 pub mod sync;
 pub mod table;
 pub mod textbox;
+pub mod tui;
 
 use std::process;
 

--- a/terminal/src/tui.rs
+++ b/terminal/src/tui.rs
@@ -13,12 +13,23 @@ use tui::backend::{Backend, CrosstermBackend};
 use tui::Terminal;
 
 pub mod events;
+pub mod store;
 pub mod window;
 
 use events::{Events, InputEvent, Key};
+use store::{Store, Value};
 use window::ApplicationWindow;
 
 pub const TICK_RATE: u64 = 200;
+
+/// Internal execution state of a tui-application. Setting the state
+/// property `app.state` to `State::Exiting` will exit the
+/// application.
+#[derive(PartialEq, Eq, Clone, Copy, Debug)]
+pub enum State {
+    Running,
+    Exiting,
+}
 
 /// Basic tui-application with no state.
 ///
@@ -27,12 +38,17 @@ pub const TICK_RATE: u64 = 200;
 /// let mut application = Application::new();
 /// application.execute()?;
 /// ```
-pub struct Application;
+pub struct Application {
+    store: Store,
+}
 
 impl Application {
-    /// Returns a default tui-application
+    /// Returns a default tui-application that can be quited.
     pub fn new() -> Self {
-        Self {}
+        let application = Self {
+            store: Store::default(),
+        };
+        application.store(vec![("app.state", Box::new(State::Running))])
     }
 
     /// Initializes backend, enters alternative screen, runs application and restores
@@ -58,7 +74,7 @@ impl Application {
     }
 
     /// Starts the render loop, the event thread and re-draws an application window.
-    /// Leave render loop if an input event for key 'q' was received.
+    /// Leave render loop if property `app.state` signals exit.
     fn run<B: Backend>(&mut self, terminal: &mut Terminal<B>) -> Result<(), Error> {
         let window = ApplicationWindow::new();
         let events = Events::new(Duration::from_millis(TICK_RATE));
@@ -68,14 +84,31 @@ impl Application {
             })?;
 
             match events.next()? {
-                InputEvent::Input(key) => {
-                    if let Key::Char('q') = key {
-                        return Ok(());
-                    }
-                }
+                InputEvent::Input(key) => self.on_key(key)?,
                 InputEvent::Tick => {}
             }
+
+            let state = self.store.get::<State>("app.state")?;
+            if *state == State::Exiting {
+                return Ok(());
+            }
         }
+    }
+
+    /// Add all given properties to internal store and return itself.
+    pub fn store(mut self, props: Vec<(&str, Value)>) -> Self {
+        for (key, prop) in props {
+            self.store.set(key, prop);
+        }
+        self
+    }
+
+    /// Handle input key and update store based on type.
+    pub fn on_key(&mut self, key: Key) -> Result<(), Error> {
+        if let Key::Char('q') = key {
+            self.store.set("app.state", Box::new(State::Exiting));
+        }
+        Ok(())
     }
 }
 

--- a/terminal/src/tui.rs
+++ b/terminal/src/tui.rs
@@ -23,7 +23,7 @@ pub mod window;
 use events::{Events, InputEvent};
 use store::{Store, Value};
 use theme::Theme;
-use window::{ApplicationWindow, ShortcutWidget};
+use window::{ApplicationWindow, ShortcutWidget, TitleWidget};
 
 pub const TICK_RATE: u64 = 200;
 
@@ -86,6 +86,7 @@ impl<'a> Application<'a> {
     /// Leave render loop if property `app.state` signals exit.
     fn run<B: Backend>(&mut self, terminal: &mut Terminal<B>, theme: &Theme) -> Result<(), Error> {
         let window = ApplicationWindow {
+            title: Rc::new(TitleWidget),
             shortcuts: Rc::new(ShortcutWidget),
         };
         let events = Events::new(Duration::from_millis(TICK_RATE));
@@ -95,7 +96,7 @@ impl<'a> Application<'a> {
                 error = window.draw(&self.store, frame, theme).err();
             })?;
             if let Some(err) = error {
-                return Err(err.into());
+                return Err(err);
             }
 
             self.on_event(events.next()?)?;

--- a/terminal/src/tui.rs
+++ b/terminal/src/tui.rs
@@ -1,0 +1,70 @@
+use std::io::stdout;
+
+use anyhow::{Error, Result};
+
+use crossterm::event::{DisableMouseCapture, EnableMouseCapture};
+use crossterm::execute;
+use crossterm::terminal::{
+    disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen,
+};
+
+use tui::backend::{Backend, CrosstermBackend};
+use tui::Terminal;
+
+pub mod window;
+
+use window::ApplicationWindow;
+
+/// Basic tui-application with no state.
+///
+/// # Example
+/// ```
+/// let mut application = Application::new();
+/// application.execute()?;
+/// ```
+pub struct Application;
+
+impl Application {
+    /// Returns a default tui-application
+    pub fn new() -> Self {
+        Self {}
+    }
+
+    /// Initializes backend, enters alternative screen, runs application and restores
+    /// terminal after application exited.
+    pub fn execute(&mut self) -> Result<(), Error> {
+        enable_raw_mode()?;
+        let mut stdout = stdout();
+        execute!(stdout, EnterAlternateScreen, EnableMouseCapture)?;
+        let backend = CrosstermBackend::new(stdout);
+        let mut terminal = Terminal::new(backend)?;
+
+        self.run(&mut terminal)?;
+
+        disable_raw_mode()?;
+        execute!(
+            terminal.backend_mut(),
+            LeaveAlternateScreen,
+            DisableMouseCapture
+        )?;
+        terminal.show_cursor()?;
+
+        Ok(())
+    }
+
+    // Starts the render loop and re-draws an application window infinitely.
+    fn run<B: Backend>(&mut self, terminal: &mut Terminal<B>) -> Result<(), Error> {
+        let window = ApplicationWindow::new();
+        loop {
+            terminal.draw(|f| {
+                let _ = window.draw(f);
+            })?;
+        }
+    }
+}
+
+impl Default for Application {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/terminal/src/tui.rs
+++ b/terminal/src/tui.rs
@@ -34,30 +34,12 @@ pub enum State {
     Exiting,
 }
 
-/// Basic, multi-threaded tui-application with default initialized store. 
-/// When creating an application, an update callback needs to be passed. 
+/// Basic, multi-threaded tui-application with default initialized store.
+/// When creating an application, an update callback needs to be passed.
 /// This will be called for every input event received from event thread.
 ///
-/// # Example
-/// ```
-/// use anyhow::{Error, Result};
-/// 
-/// use tui::{Application, State};
-/// use tui::events::InputEvent;
-/// use tui::store::Store;
-/// 
-/// fn main() {
-///     let mut application = Application::new(&update);
-///     application.execute()?;
-/// }
+/// An example application can be found in `examples/tui.rs`.
 ///
-/// fn update(store: &mut Store, event: &InputEvent) -> Result<(), Error> {
-///     if let InputEvent::Input(Key::Char('q')) = *event {
-///         store.set("app.state", Box::new(State::Exiting));
-///     }
-///     Ok(())
-/// }
-/// ```
 pub struct Application<'a> {
     store: Store,
     update: &'a Update,

--- a/terminal/src/tui.rs
+++ b/terminal/src/tui.rs
@@ -45,7 +45,7 @@ pub enum State {
 /// An example application can be found in `examples/tui.rs`.
 ///
 pub struct Application<'a> {
-    store: Store,
+    pub store: Store,
     update: &'a Update,
 }
 

--- a/terminal/src/tui.rs
+++ b/terminal/src/tui.rs
@@ -14,7 +14,9 @@ use tui::Terminal;
 
 pub mod events;
 pub mod layout;
+pub mod spans;
 pub mod store;
+pub mod strings;
 pub mod template;
 pub mod theme;
 pub mod window;

--- a/terminal/src/tui/events.rs
+++ b/terminal/src/tui/events.rs
@@ -1,0 +1,69 @@
+use std::sync::mpsc::{channel, Receiver, RecvError};
+use std::thread;
+use std::time::Duration;
+
+use crossterm::event;
+
+/// Abstraction for combinations of crossterm key events
+/// with modifiers.
+#[derive(PartialEq, Eq, Clone, Copy, Hash, Debug)]
+pub enum Key {
+    Char(char),
+    Unknown,
+}
+
+/// Converts a crossterm event to a key abstraction.
+impl From<event::KeyEvent> for Key {
+    fn from(key_event: event::KeyEvent) -> Self {
+        match key_event {
+            event::KeyEvent {
+                code: event::KeyCode::Char(c),
+                ..
+            } => Key::Char(c),
+            _ => Key::Unknown,
+        }
+    }
+}
+
+/// Encodes the event type known to the application. The event
+/// type `Input` wraps an key event and the type `Tick` can be used
+/// to update application state constantly if needed.
+pub enum InputEvent {
+    Input(Key),
+    Tick,
+}
+
+/// A small event handler that wrap crossterm input and tick event. Each event
+/// type is handled in its own thread and returned to a common `Receiver`.
+pub struct Events {
+    rx: Receiver<InputEvent>,
+}
+
+impl Events {
+    /// Spawns event thread that sends a key event (if received) and a tick event
+    /// to a MPSC channel.
+    pub fn new(tick_rate: Duration) -> Events {
+        let (tx, rx) = channel();
+
+        thread::spawn(move || loop {
+            if crossterm::event::poll(tick_rate).unwrap() {
+                if let crossterm::event::Event::Key(key) = crossterm::event::read().unwrap() {
+                    let key = Key::from(key);
+                    if tx.send(InputEvent::Input(key)).is_err() {
+                        break;
+                    }
+                }
+            }
+            if tx.send(InputEvent::Tick).is_err() {
+                break;
+            }
+        });
+
+        Events { rx }
+    }
+
+    /// Attempts to read an event. This function will block the current thread.
+    pub fn next(&self) -> Result<InputEvent, RecvError> {
+        self.rx.recv()
+    }
+}

--- a/terminal/src/tui/events.rs
+++ b/terminal/src/tui/events.rs
@@ -15,6 +15,7 @@ pub enum Key {
     Down,
     Esc,
     Enter,
+    Tab,
     Unknown,
 }
 
@@ -50,6 +51,10 @@ impl From<event::KeyEvent> for Key {
                 code: event::KeyCode::Enter,
                 ..
             } => Key::Enter,
+            event::KeyEvent {
+                code: event::KeyCode::Tab,
+                ..
+            } => Key::Tab,
             _ => Key::Unknown,
         }
     }

--- a/terminal/src/tui/events.rs
+++ b/terminal/src/tui/events.rs
@@ -9,6 +9,12 @@ use crossterm::event;
 #[derive(PartialEq, Eq, Clone, Copy, Hash, Debug)]
 pub enum Key {
     Char(char),
+    Ctrl(char),
+    Shift(char),
+    Up,
+    Down,
+    Esc,
+    Enter,
     Unknown,
 }
 
@@ -18,8 +24,32 @@ impl From<event::KeyEvent> for Key {
         match key_event {
             event::KeyEvent {
                 code: event::KeyCode::Char(c),
-                ..
+                modifiers: event::KeyModifiers::NONE,
             } => Key::Char(c),
+            event::KeyEvent {
+                code: event::KeyCode::Char(c),
+                modifiers: event::KeyModifiers::SHIFT,
+            } => Key::Shift(c),
+            event::KeyEvent {
+                code: event::KeyCode::Char(c),
+                modifiers: event::KeyModifiers::CONTROL,
+            } => Key::Ctrl(c),
+            event::KeyEvent {
+                code: event::KeyCode::Up,
+                ..
+            } => Key::Up,
+            event::KeyEvent {
+                code: event::KeyCode::Down,
+                ..
+            } => Key::Down,
+            event::KeyEvent {
+                code: event::KeyCode::Esc,
+                ..
+            } => Key::Esc,
+            event::KeyEvent {
+                code: event::KeyCode::Enter,
+                ..
+            } => Key::Enter,
             _ => Key::Unknown,
         }
     }

--- a/terminal/src/tui/layout.rs
+++ b/terminal/src/tui/layout.rs
@@ -1,9 +1,26 @@
 use tui::layout::{Constraint, Direction, Layout, Rect};
 
+pub struct Padding {
+    pub top: u16,
+    pub left: u16,
+}
+
+pub fn inner_area(area: Rect, padding: Padding) -> Rect {
+    Rect::new(
+        area.x + padding.left,
+        area.y + padding.top,
+        area.width - padding.left * 2,
+        area.height - padding.top * 2,
+    )
+}
+
 pub fn split_area(area: Rect, lengths: Vec<u16>, direction: Direction) -> Vec<Rect> {
     let constraints = lengths
         .iter()
         .map(|l| Constraint::Length(*l))
         .collect::<Vec<_>>();
-    Layout::default().direction(direction).constraints(constraints).split(area)
+    Layout::default()
+        .direction(direction)
+        .constraints(constraints)
+        .split(area)
 }

--- a/terminal/src/tui/layout.rs
+++ b/terminal/src/tui/layout.rs
@@ -1,0 +1,9 @@
+use tui::layout::{Constraint, Direction, Layout, Rect};
+
+pub fn split_area(area: Rect, lengths: Vec<u16>, direction: Direction) -> Vec<Rect> {
+    let constraints = lengths
+        .iter()
+        .map(|l| Constraint::Length(*l))
+        .collect::<Vec<_>>();
+    Layout::default().direction(direction).constraints(constraints).split(area)
+}

--- a/terminal/src/tui/spans.rs
+++ b/terminal/src/tui/spans.rs
@@ -1,0 +1,26 @@
+use textwrap::Options;
+
+use tui::style::{Color, Style};
+use tui::text::{Span, Spans};
+
+use super::strings;
+
+pub fn lines(content: &str, width: u16, indent: u16) -> Vec<Spans<'_>> {
+    let wrap = width.checked_sub(indent).unwrap_or(80);
+    let whitespaces = strings::whitespaces(indent);
+
+    let options = Options::new(wrap as usize)
+        .initial_indent(&whitespaces)
+        .subsequent_indent(&whitespaces);
+
+    let lines = textwrap::wrap(content, options);
+    lines
+        .iter()
+        .map(|line| {
+            Spans::from(Span::styled(
+                String::from(line.clone()),
+                Style::default().fg(Color::Rgb(200, 200, 200)),
+            ))
+        })
+        .collect::<Vec<_>>()
+}

--- a/terminal/src/tui/store.rs
+++ b/terminal/src/tui/store.rs
@@ -39,4 +39,125 @@ impl Store {
             None => Err(StoreError::NotFound(key.to_owned())),
         }
     }
+
+    /// Return a mutable value for given property or an error if property does
+    /// not exist or can't be casted to given type.
+    pub fn get_mut<T: Any>(&mut self, key: &str) -> Result<&mut T, StoreError> {
+        match self.properties.get_mut(key) {
+            Some(prop) => match prop.downcast_mut::<T>() {
+                Some(value) => Ok(value),
+                None => Err(StoreError::InvalidType(key.to_owned())),
+            },
+            None => Err(StoreError::NotFound(key.to_owned())),
+        }
+    }
+}
+
+/// List of items that keeps track of the selection.
+pub struct Items<T> {
+    values: Vec<T>,
+    index: usize,
+}
+
+impl<T> Items<T> {
+    pub fn all(&self) -> &Vec<T> {
+        &self.values
+    }
+
+    pub fn selected(&self) -> Option<&T> {
+        self.values.get(self.index)
+    }
+
+    pub fn select_index(&mut self, index: usize) {
+        self.index = index
+    }
+
+    pub fn selected_index(&self) -> usize {
+        self.index
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.values.is_empty()
+    }
+
+    pub fn count(&self) -> usize {
+        self.values.len()
+    }
+}
+
+/// List of items that cycles through the selection.
+pub struct TabProperty<T> {
+    items: Items<T>,
+}
+
+impl<T> TabProperty<T> {
+    pub fn new(items: Vec<T>) -> Self {
+        Self {
+            items: Items {
+                values: items,
+                index: 0,
+            },
+        }
+    }
+
+    pub fn items(&self) -> &Items<T> {
+        &self.items
+    }
+
+    pub fn select_previous(&mut self) {
+        let len = self.items.all().len();
+        let index = match self.items.selected_index() == 0 {
+            true => len - 1,
+            false => self.items.selected_index() - 1,
+        };
+        self.items.select_index(index);
+    }
+
+    pub fn select_next(&mut self) {
+        let len = self.items.all().len();
+        let index = match self.items.selected_index() >= len - 1 {
+            true => 0,
+            false => self.items.selected_index() + 1,
+        };
+        self.items.select_index(index);
+    }
+}
+
+/// List of items that won't cycle through the selection,
+/// but rather stops selecting a new item at the beginning
+/// and the end of the list.
+pub struct ListProperty<T> {
+    items: Items<T>,
+}
+
+impl<T> ListProperty<T> {
+    pub fn new(items: Vec<T>) -> Self {
+        Self {
+            items: Items {
+                values: items,
+                index: 0,
+            },
+        }
+    }
+
+    pub fn items(&self) -> &Items<T> {
+        &self.items
+    }
+
+    pub fn select_previous(&mut self) {
+        let index = match self.items.selected_index() == 0 {
+            true => 0,
+            false => self.items.selected_index() - 1,
+        };
+        self.items.select_index(index);
+    }
+
+    pub fn select_next(&mut self) {
+        let len = self.items.all().len();
+        let index = match self.items.selected_index() >= len - 1 {
+            true => len - 1,
+            false => self.items.selected_index() + 1,
+        };
+        self.items.select_index(index);
+    }
 }

--- a/terminal/src/tui/store.rs
+++ b/terminal/src/tui/store.rs
@@ -1,0 +1,42 @@
+use std::any::Any;
+use std::collections::HashMap;
+
+use anyhow::Result;
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum StoreError {
+    #[error("Invalid type requested: {0}")]
+    InvalidType(String),
+    #[error("Property not found: {0}")]
+    NotFound(String),
+}
+
+/// A generic value container that stores any type.
+pub type Value = Box<dyn Any>;
+
+/// The store properties of a tui-application accessible
+/// by a key of type `String`.
+#[derive(Default)]
+pub struct Store {
+    properties: HashMap<String, Value>,
+}
+
+impl Store {
+    /// Set a value for given property. Overwrite if it already exists.
+    pub fn set(&mut self, key: &str, value: Value) {
+        self.properties.insert(String::from(key), value);
+    }
+
+    /// Return the value of given property or an error if property does
+    /// not exist or can't be casted to given type.
+    pub fn get<T: Any>(&self, key: &str) -> Result<&T, StoreError> {
+        match self.properties.get(key) {
+            Some(prop) => match prop.downcast_ref::<T>() {
+                Some(value) => Ok(value),
+                None => Err(StoreError::InvalidType(key.to_owned())),
+            },
+            None => Err(StoreError::NotFound(key.to_owned())),
+        }
+    }
+}

--- a/terminal/src/tui/strings.rs
+++ b/terminal/src/tui/strings.rs
@@ -1,0 +1,6 @@
+pub fn whitespaces(indent: u16) -> String {
+    match String::from_utf8(vec![b' '; indent as usize]) {
+        Ok(spaces) => spaces,
+        Err(_) => String::new(),
+    }
+}

--- a/terminal/src/tui/template.rs
+++ b/terminal/src/tui/template.rs
@@ -1,5 +1,7 @@
 use tui::layout::Rect;
-use tui::widgets::{Block, Borders};
+use tui::style::Style;
+use tui::text::{Span, Spans};
+use tui::widgets::{Block, Borders, Paragraph};
 
 use super::layout;
 use super::layout::Padding;
@@ -24,4 +26,11 @@ pub fn block(theme: &Theme, area: Rect, padding: Padding, borders: bool) -> (Blo
 
     let inner = layout::inner_area(area, padding);
     (block, inner)
+}
+
+pub fn paragraph(text: &String, style: Style) -> Paragraph {
+    let text = format!("{:1}{}{:1}", "", text, "");
+    let text = Span::styled(text, style);
+
+    Paragraph::new(vec![Spans::from(text)])
 }

--- a/terminal/src/tui/template.rs
+++ b/terminal/src/tui/template.rs
@@ -1,7 +1,7 @@
 use tui::layout::Rect;
 use tui::style::Style;
 use tui::text::{Span, Spans};
-use tui::widgets::{Block, Borders, Paragraph};
+use tui::widgets::{Block, Borders, List, ListItem, ListState, Paragraph};
 
 use super::layout;
 use super::layout::Padding;
@@ -33,4 +33,27 @@ pub fn paragraph(text: &String, style: Style) -> Paragraph {
     let text = Span::styled(text, style);
 
     Paragraph::new(vec![Spans::from(text)])
+}
+
+pub fn paragraph_styled(text: &String, style: Style) -> Paragraph {
+    let text = format!("{:1}{}{:1}", "", text, "");
+    let text = Span::styled(text, style);
+
+    Paragraph::new(vec![Spans::from(text)]).style(style)
+}
+
+pub fn list<'a>(
+    items: Vec<ListItem<'a>>,
+    selected: usize,
+    theme: &'a Theme,
+) -> (List<'a>, ListState) {
+    let mut state = ListState::default();
+    state.select(Some(selected));
+
+    let items = List::new(items)
+        .highlight_style(theme.highlight)
+        .highlight_symbol(&theme.list.symbol)
+        .repeat_highlight_symbol(true);
+
+    (items, state)
 }

--- a/terminal/src/tui/template.rs
+++ b/terminal/src/tui/template.rs
@@ -1,0 +1,27 @@
+use tui::layout::Rect;
+use tui::widgets::{Block, Borders};
+
+use super::layout;
+use super::layout::Padding;
+use super::theme::Theme;
+
+pub fn block(theme: &Theme, area: Rect, padding: Padding, borders: bool) -> (Block, Rect) {
+    let borders = match borders {
+        true => theme.border.borders,
+        false => Borders::NONE,
+    };
+    let block = Block::default()
+        .borders(borders)
+        .border_style(theme.border.style)
+        .border_type(theme.border.border_type);
+    let padding = match theme.border.borders {
+        Borders::NONE => padding,
+        _ => Padding {
+            top: padding.top,
+            left: padding.left,
+        },
+    };
+
+    let inner = layout::inner_area(area, padding);
+    (block, inner)
+}

--- a/terminal/src/tui/theme.rs
+++ b/terminal/src/tui/theme.rs
@@ -1,0 +1,113 @@
+use tui::style::{Color, Modifier, Style};
+use tui::widgets::{BorderType, Borders};
+
+pub struct BorderStyle {
+    pub style: Style,
+    pub borders: Borders,
+    pub border_type: BorderType,
+}
+
+pub struct ListStyle {
+    pub symbol: String,
+}
+
+pub struct Theme {
+    pub border: BorderStyle,
+    pub list: ListStyle,
+    pub highlight: Style,
+    pub highlight_dim: Style,
+    pub highlight_invert: Style,
+    pub primary: Style,
+    pub primary_dim: Style,
+    pub primary_invert: Style,
+    pub secondary: Style,
+    pub secondary_dim: Style,
+    pub ternary: Style,
+    pub ternary_dim: Style,
+    pub bg_dark_secondary: Style,
+    pub bg_bright_primary: Style,
+    pub bg_bright_ternary: Style,
+    pub open: Style,
+    pub solved: Style,
+    pub closed: Style,
+}
+
+impl Theme {
+    pub fn default_dark() -> Self {
+        Theme {
+            border: BorderStyle {
+                style: Style::default(),
+                borders: Borders::NONE,
+                border_type: BorderType::Plain,
+            },
+            list: ListStyle {
+                symbol: String::from("│ "),
+            },
+            highlight: Style::default().fg(Color::Rgb(238, 111, 248)),
+            highlight_dim: Style::default()
+                .fg(Color::Rgb(255, 255, 255))
+                .add_modifier(Modifier::BOLD),
+            highlight_invert: Style::default()
+                .bg(Color::Rgb(238, 111, 248))
+                .fg(Color::White)
+                .add_modifier(Modifier::BOLD),
+            primary: Style::default().fg(Color::Rgb(117, 113, 249)),
+            primary_dim: Style::default().fg(Color::Rgb(79, 75, 187)),
+            primary_invert: Style::default()
+                .bg(Color::Rgb(79, 75, 187))
+                .fg(Color::White)
+                .add_modifier(Modifier::BOLD),
+            secondary: Style::default().fg(Color::Rgb(66, 245, 161)),
+            secondary_dim: Style::default().fg(Color::Rgb(30, 102, 68)),
+            ternary: Style::default().fg(Color::Rgb(100, 100, 100)),
+            ternary_dim: Style::default().fg(Color::Rgb(70, 70, 70)),
+            bg_dark_secondary: Style::default()
+                .fg(Color::Rgb(100, 100, 100))
+                .bg(Color::Rgb(50, 50, 50)),
+            bg_bright_primary: Style::default()
+                .fg(Color::Rgb(117, 113, 249))
+                .bg(Color::Rgb(40, 40, 40)),
+            bg_bright_ternary: Style::default()
+                .fg(Color::Rgb(100, 100, 100))
+                .bg(Color::Rgb(40, 40, 40)),
+            open: Style::default().fg(Color::Blue),
+            solved: Style::default().fg(Color::Rgb(66, 245, 161)),
+            closed: Style::default().fg(Color::Red),
+        }
+    }
+
+    pub fn glow_dark() -> Self {
+        Theme {
+            border: BorderStyle {
+                style: Style::default().fg(Color::Rgb(80, 80, 80)),
+                borders: Borders::ALL,
+                border_type: BorderType::Rounded,
+            },
+            list: ListStyle {
+                symbol: String::from("│ "),
+            },
+            highlight: Style::default().fg(Color::Rgb(238, 111, 248)),
+            highlight_dim: Style::default()
+                .fg(Color::Rgb(255, 255, 255))
+                .add_modifier(Modifier::BOLD),
+            highlight_invert: Style::default()
+                .fg(Color::Rgb(238, 111, 248))
+                .add_modifier(Modifier::BOLD),
+            primary: Style::default().fg(Color::Rgb(117, 113, 249)),
+            primary_dim: Style::default().fg(Color::Rgb(79, 75, 187)),
+            primary_invert: Style::default()
+                .fg(Color::Rgb(117, 113, 249))
+                .add_modifier(Modifier::BOLD),
+            secondary: Style::default().fg(Color::Rgb(66, 245, 161)),
+            secondary_dim: Style::default().fg(Color::Rgb(30, 102, 68)),
+            ternary: Style::default().fg(Color::Rgb(100, 100, 100)),
+            ternary_dim: Style::default().fg(Color::Rgb(70, 70, 70)),
+            bg_dark_secondary: Style::default().fg(Color::Rgb(30, 102, 68)),
+            bg_bright_primary: Style::default().fg(Color::Rgb(117, 113, 249)),
+            bg_bright_ternary: Style::default().fg(Color::Rgb(100, 100, 100)),
+            open: Style::default().fg(Color::Blue),
+            solved: Style::default().fg(Color::Rgb(66, 245, 161)),
+            closed: Style::default().fg(Color::Red),
+        }
+    }
+}

--- a/terminal/src/tui/window.rs
+++ b/terminal/src/tui/window.rs
@@ -1,29 +1,59 @@
+use std::rc::Rc;
+
 use anyhow::{Error, Result};
 
 use tui::backend::Backend;
-use tui::style::Style;
-use tui::widgets::Block;
+use tui::layout::{Direction, Rect};
+use tui::widgets::{Block, Borders};
 use tui::Frame;
 
-/// Basic application window with no widgets.
-pub struct ApplicationWindow;
+use super::layout;
+use super::store::Store;
 
-impl ApplicationWindow {
-    /// Returns a new application window.
-    pub fn new() -> Self {
-        Self {}
-    }
+/// Basic application window with layout for shortcut widget.
+pub struct ApplicationWindow<B: Backend> {
+    pub shortcuts: Rc<dyn Widget<B>>,
+}
 
-    /// Draws the application window to given `frame`.
-    pub fn draw<B: Backend>(&self, frame: &mut Frame<B>) -> Result<(), Error> {
-        let block = Block::default().title("tui").style(Style::default());
-        frame.render_widget(block, frame.size());
+impl<B> ApplicationWindow<B>
+where
+    B: Backend,
+{
+    /// Draw the application window to given `frame`.
+    pub fn draw(&self, frame: &mut Frame<B>, store: &Store) -> Result<(), Error> {
+        let shortcut_h = self.shortcuts.height(frame.size());
+        let areas = layout::split_area(frame.size(), vec![shortcut_h], Direction::Vertical);
+
+        self.shortcuts.draw(frame, areas[0], store)?;
         Ok(())
     }
 }
 
-impl Default for ApplicationWindow {
-    fn default() -> Self {
-        Self::new()
+/// Trait that must be implemented by custom application widgets.
+pub trait Widget<B: Backend> {
+    /// Draw widget to `frame` on the `area` defined and the application `store`
+    /// given. Called by the application if drawing is requested.
+    fn draw(&self, frame: &mut Frame<B>, area: Rect, store: &Store) -> Result<(), Error>;
+    /// Return height of widget. Used while layouting.
+    fn height(&self, area: Rect) -> u16;
+}
+
+/// An empty widget with no height. Can be used as placeholder.
+#[derive(Copy, Clone)]
+pub struct EmptyWidget;
+
+impl<B> Widget<B> for EmptyWidget
+where
+    B: Backend,
+{
+    fn draw(&self, frame: &mut Frame<B>, area: Rect, _store: &Store) -> Result<(), Error> {
+        let block = Block::default().borders(Borders::NONE);
+        frame.render_widget(block, area);
+
+        Ok(())
+    }
+
+    fn height(&self, _area: Rect) -> u16 {
+        0_u16
     }
 }

--- a/terminal/src/tui/window.rs
+++ b/terminal/src/tui/window.rs
@@ -9,6 +9,7 @@ use tui::Frame;
 
 use super::layout;
 use super::store::Store;
+use super::theme::Theme;
 
 /// Basic application window with layout for shortcut widget.
 pub struct ApplicationWindow<B: Backend> {
@@ -20,11 +21,11 @@ where
     B: Backend,
 {
     /// Draw the application window to given `frame`.
-    pub fn draw(&self, frame: &mut Frame<B>, store: &Store) -> Result<(), Error> {
+    pub fn draw(&self, store: &Store, frame: &mut Frame<B>, theme: &Theme) -> Result<(), Error> {
         let shortcut_h = self.shortcuts.height(frame.size());
         let areas = layout::split_area(frame.size(), vec![shortcut_h], Direction::Vertical);
 
-        self.shortcuts.draw(frame, areas[0], store)?;
+        self.shortcuts.draw(store, frame, areas[0], theme)?;
         Ok(())
     }
 }
@@ -33,7 +34,13 @@ where
 pub trait Widget<B: Backend> {
     /// Draw widget to `frame` on the `area` defined and the application `store`
     /// given. Called by the application if drawing is requested.
-    fn draw(&self, frame: &mut Frame<B>, area: Rect, store: &Store) -> Result<(), Error>;
+    fn draw(
+        &self,
+        store: &Store,
+        frame: &mut Frame<B>,
+        area: Rect,
+        theme: &Theme,
+    ) -> Result<(), Error>;
     /// Return height of widget. Used while layouting.
     fn height(&self, area: Rect) -> u16;
 }
@@ -46,7 +53,13 @@ impl<B> Widget<B> for EmptyWidget
 where
     B: Backend,
 {
-    fn draw(&self, frame: &mut Frame<B>, area: Rect, _store: &Store) -> Result<(), Error> {
+    fn draw(
+        &self,
+        _store: &Store,
+        frame: &mut Frame<B>,
+        area: Rect,
+        _theme: &Theme,
+    ) -> Result<(), Error> {
         let block = Block::default().borders(Borders::NONE);
         frame.render_widget(block, area);
 

--- a/terminal/src/tui/window.rs
+++ b/terminal/src/tui/window.rs
@@ -1,0 +1,29 @@
+use anyhow::{Error, Result};
+
+use tui::backend::Backend;
+use tui::style::Style;
+use tui::widgets::Block;
+use tui::Frame;
+
+/// Basic application window with no widgets.
+pub struct ApplicationWindow;
+
+impl ApplicationWindow {
+    /// Returns a new application window.
+    pub fn new() -> Self {
+        Self {}
+    }
+
+    /// Draws the application window to given `frame`.
+    pub fn draw<B: Backend>(&self, frame: &mut Frame<B>) -> Result<(), Error> {
+        let block = Block::default().title("tui").style(Style::default());
+        frame.render_widget(block, frame.size());
+        Ok(())
+    }
+}
+
+impl Default for ApplicationWindow {
+    fn default() -> Self {
+        Self::new()
+    }
+}


### PR DESCRIPTION
## Description

This adds a TUI library based on `tui-rs` that comes with:
- generic key-value store for application properties
- common widgets and support for application specific ones
- separate render and event thread
- stacked, multi-page layout
- 2 predefined theme(s): default and with borders
- example application(s): 
  - basic: `example/tui.rs`
  - custom widget: `example/tui_widget.rs`
  - re-run after internal call: `example/tui_internal_call.rs`

## Examples

![Screenshot from 2022-06-21 16-58-30](https://user-images.githubusercontent.com/20012009/174831844-f637ebae-2019-4334-92b0-b4a2b6d3888f.png)
![Screenshot from 2022-06-21 16-58-08](https://user-images.githubusercontent.com/20012009/174831869-092c3a29-6c29-4637-8680-16193cfabca8.png)

