### PR TITLE
Add release profile to Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,12 @@ inherits = "dev"
 debug = 0
 incremental = false
 
+[profile.release]
+strip = true
+lto = true
+codegen-units = 1
+panic = "abort"
+
 [features]
 default = ["ethereum"]
 ethereum = ["rad-ens", "rad-account", "rad-help/ethereum", "rad-gov", "rad-reward", "ethers", "futures"]


### PR DESCRIPTION
This profile significantly reduces the size of release binaries. As an example `rad-gov` is now only 5.8 MB, down from 20 MB.

We can also use `upx --best --lzma <bin>` and get up to 70% more compression on the binary. Basic testing shows around 200ms added to startup time, which depending on the use case might or might not be worth it.