### PR TITLE
Support message flags for patch creation

### DIFF
--- a/scripts/contributor-workflow-setup.sh
+++ b/scripts/contributor-workflow-setup.sh
@@ -94,7 +94,7 @@ git commit -m "Update README" --no-gpg-sign
 # Push commit to monorepo
 rad push
 # Create patch
-rad patch --sync
+rad patch --sync --message "Update README" --message "Reflect the recent positive news"
 # Sync identity
 rad sync --self
 


### PR DESCRIPTION
Use '--message' to set the patches title and description on creation to reduce required human intervention.  The description field is also made optional.