### PR TITLE
Make '--message' consistent across commands

### DIFF
--- a/comment/src/lib.rs
+++ b/comment/src/lib.rs
@@ -10,6 +10,7 @@ use radicle_common::{
     keys, project,
 };
 use radicle_terminal as term;
+use radicle_terminal::patch::Comment;
 
 pub const HELP: Help = Help {
     name: "comment",
@@ -31,7 +32,7 @@ Options
 #[derive(Debug)]
 pub struct Options {
     pub id: cobs::Identifier,
-    pub message: Option<String>,
+    pub message: Comment,
     pub reply_index: Option<CommentId>,
 }
 
@@ -41,7 +42,7 @@ impl Args for Options {
 
         let mut parser = lexopt::Parser::from_args(args);
         let mut id: Option<cobs::Identifier> = None;
-        let mut message: Option<String> = None;
+        let mut message = Comment::default();
         let mut reply_index: Option<CommentId> = None;
 
         while let Some(arg) = parser.next()? {
@@ -50,7 +51,8 @@ impl Args for Options {
                     return Err(Error::Help.into());
                 }
                 Long("message") | Short('m') => {
-                    message = Some(parser.value()?.to_string_lossy().into());
+                    let txt: String = parser.value()?.to_string_lossy().into();
+                    message.append(&txt);
                 }
                 Long("reply-to") => {
                     let idx = parser
@@ -95,28 +97,28 @@ pub fn run(options: Options, ctx: impl term::Context) -> anyhow::Result<()> {
     let cobs = cobs::store(&profile, &storage)?;
     let cob_id = options.id;
 
-    let doc = options
-        .message
-        .unwrap_or("Enter a comment message...".to_owned());
+    let message = options.message.get("Enter a comment message...");
+    if message.is_empty() {
+        return Ok(());
+    }
 
-    if let Some(text) = term::Editor::new().edit(&doc)? {
-        if let Some(id) = cobs.resolve_id::<issue::Issue>(&project, &cob_id)? {
-            if let Some(reply_to_index) = options.reply_index {
-                cobs.issues().reply(&project, &id, reply_to_index, &text)?;
-            } else {
-                cobs.issues().comment(&project, &id, &text)?;
-            }
-        } else if let Some((id, patch)) = cobs.resolve::<patch::Patch>(&project, &cob_id)? {
-            if let Some(reply_to_index) = options.reply_index {
-                cobs.patches()
-                    .reply(&project, &id, patch.version(), reply_to_index, &text)?;
-            } else {
-                cobs.patches()
-                    .comment(&project, &id, patch.version(), &text)?;
-            }
+    if let Some(id) = cobs.resolve_id::<issue::Issue>(&project, &cob_id)? {
+        if let Some(reply_to_index) = options.reply_index {
+            cobs.issues()
+                .reply(&project, &id, reply_to_index, &message)?;
         } else {
-            anyhow::bail!("Couldn't find issue or patch {}", cob_id);
+            cobs.issues().comment(&project, &id, &message)?;
         }
+    } else if let Some((id, patch)) = cobs.resolve::<patch::Patch>(&project, &cob_id)? {
+        if let Some(reply_to_index) = options.reply_index {
+            cobs.patches()
+                .reply(&project, &id, patch.version(), reply_to_index, &message)?;
+        } else {
+            cobs.patches()
+                .comment(&project, &id, patch.version(), &message)?;
+        }
+    } else {
+        anyhow::bail!("Couldn't find issue or patch {}", cob_id);
     }
 
     Ok(())

--- a/patch/src/lib.rs
+++ b/patch/src/lib.rs
@@ -111,11 +111,7 @@ impl Args for Options {
                 }
                 Long("message") | Short('m') => {
                     let txt: String = parser.value()?.to_string_lossy().into();
-                    if let Comment::Text(msg) = message {
-                        message = Comment::Text(msg + "\n\n" + &txt);
-                    } else {
-                        message = Comment::Text(txt.to_string());
-                    }
+                    message.append(&txt);
                 }
                 Long("no-message") => {
                     message = Comment::Blank;

--- a/review/src/lib.rs
+++ b/review/src/lib.rs
@@ -30,8 +30,8 @@ Options
 
     -r, --revision <number>   Revision number to review, defaults to the latest
         --[no-]sync           Sync review to seed (default: sync)
-    -m, --message [<string>]  Provide a comment with the review
-        --no-wmessage         Don't provide a comment with the review
+    -m, --message [<string>]  Provide a comment with the review (default: prompt)
+        --no-message          Don't provide a comment with the review
         --help                Print help
 "#,
 };
@@ -88,7 +88,8 @@ impl Args for Options {
                     sync = false;
                 }
                 Long("message") | Short('m') => {
-                    message = Comment::Text(parser.value()?.to_string_lossy().into());
+                    let txt: String = parser.value()?.to_string_lossy().into();
+                    message.append(&txt);
                 }
                 Long("no-message") => {
                     message = Comment::Blank;

--- a/terminal/src/patch.rs
+++ b/terminal/src/patch.rs
@@ -4,7 +4,7 @@ use radicle_common::git;
 use crate as term;
 
 /// How a comment is to be supplied by the user for a patch or issue on the terminal.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub enum Comment {
     /// Prompt user to write comment in editor.
     Edit,
@@ -31,6 +31,14 @@ impl Comment {
         let comment = comment.trim();
 
         comment.to_owned()
+    }
+
+    pub fn append(&mut self, arg: &str) {
+        if let Comment::Text(v) = self {
+            v.extend(["\n\n", arg]);
+        } else {
+            *self = Comment::Text(arg.into());
+        };
     }
 }
 


### PR DESCRIPTION
Update '--comment' and '--review' to use the '--message' option the same way as patch where additional '--message' arguments are appended together.