### PR TITLE
untrack: cleanup the peer's rad remote

### DIFF
--- a/remote/src/lib.rs
+++ b/remote/src/lib.rs
@@ -4,9 +4,7 @@ use std::ffi::OsString;
 use anyhow::anyhow;
 use anyhow::Context as _;
 
-use librad::git::storage::Storage;
 use librad::git::tracking;
-use librad::git::Urn;
 use librad::PeerId;
 
 use radicle_common::args::{Args, Error, Help};
@@ -108,33 +106,6 @@ impl Args for Options {
     }
 }
 
-fn find_remote(
-    remote: &String,
-    storage: &Storage,
-    repo: &git::Repository,
-    urn: &Urn,
-) -> anyhow::Result<Option<String>> {
-    if let Ok(peer_) = remote.parse() {
-        // by Peer ID
-        for (name, peer) in git::remotes(repo)? {
-            if peer == peer_ {
-                return Ok(Some(name));
-            }
-        }
-        return Ok(None);
-    }
-
-    // by person's name
-    for (name, peer) in git::remotes(repo)? {
-        if let Some(person) = project::person(&storage, urn.clone(), &peer)? {
-            if person.subject().name.to_string() == *remote {
-                return Ok(Some(name));
-            }
-        }
-    }
-    Ok(None)
-}
-
 pub fn run(options: Options, ctx: impl term::Context) -> anyhow::Result<()> {
     let profile = ctx.profile()?;
     let signer = term::signer(&profile)?;
@@ -172,19 +143,7 @@ pub fn run(options: Options, ctx: impl term::Context) -> anyhow::Result<()> {
                 term::format::highlight(&name)
             );
         }
-        Operation::Remove { remote } => match find_remote(&remote, &storage, &repo, &urn)? {
-            Some(name) => {
-                repo.remote_delete(&name)?;
-                term::success!(
-                    "Remote {} {} removed",
-                    term::format::highlight(&remote),
-                    term::format::dim(format!("{:?}", name)),
-                );
-            }
-            None => {
-                anyhow::bail!("remote '{}' not found", remote)
-            }
-        },
+        Operation::Remove { remote } => term::remote::remove(&remote, &storage, &repo, &urn)?,
         Operation::List => {
             let mut table = term::Table::default();
             let proj = project::get(&storage, &urn)?

--- a/remote/src/lib.rs
+++ b/remote/src/lib.rs
@@ -1,4 +1,3 @@
-use std::collections::HashSet;
 use std::ffi::OsString;
 
 use anyhow::anyhow;
@@ -144,36 +143,7 @@ pub fn run(options: Options, ctx: impl term::Context) -> anyhow::Result<()> {
             );
         }
         Operation::Remove { remote } => term::remote::remove(&remote, &storage, &repo, &urn)?,
-        Operation::List => {
-            let mut table = term::Table::default();
-            let proj = project::get(&storage, &urn)?
-                .ok_or_else(|| anyhow!("project {} not found on local device", urn))?;
-            let mut peers = HashSet::new();
-
-            for (_, peer) in git::remotes(&repo)? {
-                if !peers.insert(peer) {
-                    // Don't show duplicate peers.
-                    continue;
-                }
-
-                let delegate = if proj.remotes.contains(&peer) {
-                    term::format::badge_primary("delegate")
-                } else {
-                    String::new()
-                };
-
-                if let Some(person) = project::person(&storage, urn.clone(), &peer)? {
-                    table.push([
-                        term::format::bold(person.subject().name.to_string()),
-                        term::format::tertiary(peer),
-                        delegate,
-                    ]);
-                } else {
-                    table.push([String::new(), term::format::tertiary(peer), delegate]);
-                }
-            }
-            table.render();
-        }
+        Operation::List => term::remote::list(&storage, &repo, &urn)?,
     }
 
     Ok(())

--- a/rm/src/lib.rs
+++ b/rm/src/lib.rs
@@ -128,7 +128,7 @@ pub fn run(options: Options, ctx: impl term::Context) -> anyhow::Result<()> {
                     term::format::dim(namespace.display())
                 ))
             {
-                rad_untrack::execute(urn, rad_untrack::Options { peer: None }, &profile)?;
+                rad_untrack::execute(&urn, None, rad_untrack::Options { peer: None }, &profile)?;
                 fs::remove_dir_all(namespace)?;
                 term::success!("Successfully removed project {}", &urn);
             }

--- a/rm/src/lib.rs
+++ b/rm/src/lib.rs
@@ -128,7 +128,7 @@ pub fn run(options: Options, ctx: impl term::Context) -> anyhow::Result<()> {
                     term::format::dim(namespace.display())
                 ))
             {
-                rad_untrack::execute(&urn, None, rad_untrack::Options { peer: None }, &profile)?;
+                rad_untrack::execute(urn, None, rad_untrack::Options { peer: None }, &profile)?;
                 fs::remove_dir_all(namespace)?;
                 term::success!("Successfully removed project {}", &urn);
             }

--- a/terminal/src/lib.rs
+++ b/terminal/src/lib.rs
@@ -7,6 +7,7 @@ pub mod format;
 pub mod io;
 pub mod keys;
 pub mod patch;
+pub mod remote;
 pub mod spinner;
 pub mod sync;
 pub mod table;

--- a/terminal/src/remote.rs
+++ b/terminal/src/remote.rs
@@ -1,0 +1,64 @@
+use std::collections::HashSet;
+
+use librad::git::storage::Storage;
+use librad::git::Urn;
+
+use radicle_common::{git, project};
+
+use crate as term;
+
+pub fn list(storage: &Storage, repo: &git::Repository, urn: &Urn) -> anyhow::Result<()> {
+    let mut table = term::Table::default();
+    let proj = project::get(&storage, urn)?
+        .ok_or_else(|| anyhow::anyhow!("project {} not found on local device", urn))?;
+    let mut peers = HashSet::new();
+
+    for (_, peer) in git::remotes(repo)? {
+        if !peers.insert(peer) {
+            // Don't show duplicate peers.
+            continue;
+        }
+
+        let delegate = if proj.remotes.contains(&peer) {
+            term::format::badge_primary("delegate")
+        } else {
+            String::new()
+        };
+
+        if let Some(person) = project::person(&storage, urn.clone(), &peer)? {
+            table.push([
+                term::format::bold(person.subject().name.to_string()),
+                term::format::tertiary(peer),
+                delegate,
+            ]);
+        } else {
+            table.push([String::new(), term::format::tertiary(peer), delegate]);
+        }
+    }
+    table.render();
+
+    Ok(())
+}
+
+pub fn remove(
+    name: &str,
+    storage: &Storage,
+    repo: &git::Repository,
+    urn: &Urn,
+) -> anyhow::Result<()> {
+    match project::find_remote(name, storage, repo, urn)? {
+        Some(name) => {
+            repo.remote_delete(&name)?;
+            term::success!(
+                "Remote {} {} removed",
+                term::format::highlight(&name),
+                term::format::dim(format!("{:?}", name)),
+            );
+        }
+        None => {
+            anyhow::bail!("remote '{}' not found", name)
+        }
+    }
+
+    Ok(())
+}

--- a/untrack/src/lib.rs
+++ b/untrack/src/lib.rs
@@ -136,7 +136,7 @@ pub fn execute(
             term::format::highlight(urn)
         );
     } else {
-        tracking::untrack_all(
+        let all_untracked = tracking::untrack_all(
             &storage,
             urn,
             tracking::UntrackAllArgs {
@@ -144,6 +144,13 @@ pub fn execute(
                 prune: true,
             },
         )?;
+
+        if let Some(repo) = repo {
+            for p in all_untracked.untracked.flatten() {
+                term::remote::remove(&p.remote.to_string(), &storage, repo, urn)?;
+            }
+        };
+
         term::success!(
             "Tracking relationships for {} removed",
             term::format::highlight(urn)


### PR DESCRIPTION
Remove the projects rad remote for the peer being untracked.  This is to aid cleaning up and undoing the effects of the 'track' command.

When run from outside a project context via external commands, like 'rad-rm', the cleanup step is skipped.

#159 