### PR TITLE
track,checkout: inform user about new git remote

### DIFF
--- a/checkout/src/lib.rs
+++ b/checkout/src/lib.rs
@@ -160,10 +160,11 @@ pub fn execute(options: Options, profile: &profile::Profile) -> anyhow::Result<P
                         peer.default_encoding()
                     };
 
-                    if let Some(upstream) = setup.run(peer, &name, profile)? {
+                    if let Some((remote, branch)) = setup.run(peer, &name, profile)? {
+                        term::success!("Remote {} set", term::format::highlight(remote.name),);
                         term::success!(
                             "Remote-tracking branch {} created for {}",
-                            term::format::highlight(&upstream),
+                            term::format::highlight(&branch),
                             term::format::tertiary(fmt::peer(peer))
                         );
                     }

--- a/common/src/project.rs
+++ b/common/src/project.rs
@@ -544,7 +544,7 @@ impl<'a> SetupRemote<'a> {
         peer: &PeerId,
         name: &str,
         profile: &Profile,
-    ) -> anyhow::Result<Option<String>> {
+    ) -> anyhow::Result<Option<(Remote<LocalUrl>, String)>> {
         let repo = self.repo;
         let urn = &self.project.urn;
 
@@ -566,7 +566,7 @@ impl<'a> SetupRemote<'a> {
             let branch =
                 git::set_tracking(repo.path(), &peer_prefix, &self.project.default_branch)?;
 
-            return Ok(Some(branch));
+            return Ok(Some((remote, branch)));
         }
         Ok(None)
     }

--- a/track/src/lib.rs
+++ b/track/src/lib.rs
@@ -176,10 +176,11 @@ pub fn track(
         }
         .run(&peer, &name, &profile)?;
 
-        if let Some(branch) = branch {
+        if let Some((remote, branch)) = branch {
+            term::success!("Remote {} set", term::format::highlight(remote.name),);
             term::success!(
                 "Remote-tracking branch {} set",
-                term::format::highlight(branch)
+                term::format::highlight(branch),
             );
         }
     }


### PR DESCRIPTION
Communicate to the user when a new git remote is added, on its own line.

References issue #159