### PR TITLE
Reduce import complexity for git mod

### DIFF
--- a/common/src/git.rs
+++ b/common/src/git.rs
@@ -16,8 +16,8 @@ use librad::reflike;
 use librad::{crypto::BoxedSigner, PeerId};
 
 pub use git2::{
-    build::CheckoutBuilder, AnnotatedCommit, Commit, ErrorCode, MergeAnalysis, MergeOptions, Oid,
-    Reference, Repository, Signature,
+    build::CheckoutBuilder, AnnotatedCommit, Commit, Direction, ErrorCode, MergeAnalysis,
+    MergeOptions, Oid, Reference, Repository, Signature,
 };
 pub use librad::git::local::transport;
 pub use librad::git::types::remote::LocalFetchspec;

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -46,7 +46,7 @@ pub mod fmt {
     }
 
     /// Format a git Oid.
-    pub fn oid(oid: &git2::Oid) -> String {
+    pub fn oid(oid: &super::git::Oid) -> String {
         format!("{:.7}", oid)
     }
 

--- a/common/src/seed.rs
+++ b/common/src/seed.rs
@@ -272,7 +272,7 @@ pub fn get_seed_id(mut seed: Url) -> Result<PeerId, anyhow::Error> {
 pub fn get_commit(
     mut seed: Url,
     project: &Urn,
-    commit: &git2::Oid,
+    commit: &git::Oid,
 ) -> Result<Commit, anyhow::Error> {
     seed.set_port(Some(DEFAULT_SEED_API_PORT)).unwrap();
     seed = seed.join(&format!("/v1/projects/{}/commits/{}", project, commit))?;


### PR DESCRIPTION
Use common::git in place of the git2 module in many cases.  Git2 is re-exported by common::git as the project's git library.