### PR TITLE
gov: fix compile time error due to dep error

### DIFF
--- a/gov/Cargo.toml
+++ b/gov/Cargo.toml
@@ -10,7 +10,7 @@ description = "Interact with Radicle governance contracts"
 anyhow = "1.0"
 librad = "0"
 lexopt = "0.2"
-radicle-terminal = { path = "../terminal" }
+radicle-terminal = { path = "../terminal", features = ["ethereum"] }
 radicle-common = { path = "../common", features = ["ethereum"] }
 ethers = "0.6"
 thiserror = "1.0"


### PR DESCRIPTION
Add the 'ethereum' feature to radicle-terminal to fix a compile time
error.

Fixes issue #196 