### PR TITLE
Replace colored_json with json-color

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -914,19 +914,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "colored_json"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd32eb54d016e203b7c2600e3a7802c75843a92e38ccc4869aefeca21771a64"
-dependencies = [
- "ansi_term",
- "atty",
- "libc",
- "serde",
- "serde_json",
-]
-
-[[package]]
 name = "concurrent-queue"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2816,6 +2803,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "json-color"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6dc8c55175cad7234a98cc3e31ba3009e276800271692ed3ad2c2f1c574b6e8"
+dependencies = [
+ "colored 1.9.3",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "jsonrpc-core"
 version = "18.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4533,7 +4531,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "chrono",
- "colored_json",
+ "json-color",
  "lexopt",
  "librad",
  "radicle-common",
@@ -5464,6 +5462,7 @@ version = "1.0.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f972498cf015f7c0746cac89ebe1d6ef10c293b94175a243a2d9442c163d9944"
 dependencies = [
+ "indexmap",
  "itoa 1.0.1",
  "ryu",
  "serde",

--- a/inspect/Cargo.toml
+++ b/inspect/Cargo.toml
@@ -13,5 +13,5 @@ lexopt = "0.2"
 radicle-terminal = { path = "../terminal" }
 radicle-common = { path = "../common" }
 serde_json = "1.0"
-colored_json = "2.1.0"
+json-color = "0.7"
 chrono = "0.4"


### PR DESCRIPTION
Signed-off-by: Miss M <MissM_signed@protonmail.ch>

Taking initial cheap shot at it - replacing with equally not-active crate

Bonus: one less dependency to ansi_term - this uses colored crate instead

json-color dependency tree:
```
color v0.1.0 (/home/radicle/play/color)
└── json-color v0.7.1
    ├── colored v1.9.3
    │   ├── atty v0.2.14
    │   │   └── libc v0.2.132
    │   └── lazy_static v1.4.0
    ├── serde v1.0.144
    └── serde_json v1.0.85
        ├── indexmap v1.9.1
        │   └── hashbrown v0.12.3
        │   [build-dependencies]
        │   └── autocfg v1.1.0
        ├── itoa v1.0.3
        ├── ryu v1.0.11
        └── serde v1.0.144

```
