### PR TITLE
Bump Chrono to 0.4.22 and remove time 0.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -55,6 +55,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7ed72e1635e121ca3e79420540282af22da58be50de153d36f81ddc6b83aa9e"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "ansi_term"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -681,14 +690,13 @@ checksum = "17cc5e6b5ab06331c33589842070416baa137e8b0eb912b008cfd4a78ada7919"
 
 [[package]]
 name = "chrono"
-version = "0.4.19"
+version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
+checksum = "bfd4d1b31faaa3a89d7934dbded3111da0d2ef28e3ebccdb4f0179f5929d1ef1"
 dependencies = [
- "libc",
+ "iana-time-zone",
  "num-integer",
  "num-traits",
- "time 0.1.43",
  "winapi 0.3.9",
 ]
 
@@ -2581,6 +2589,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad2bfd338099682614d3ee3fe0cd72e0b6a41ca6a87f6a74a3bd593c91650501"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "js-sys",
+ "wasm-bindgen",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "idna"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2795,9 +2816,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.57"
+version = "0.3.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "671a26f820db17c2a2750743f1dd03bafd15b98c9f30c7c2628c024c05d73397"
+checksum = "c3fac17f7123a73ca62df411b1bf727ccc805daa070338fda671c86dac1bdc27"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -2906,9 +2927,9 @@ checksum = "de7513aea7d10dc0694d719ac53de3b74f1600e41b9f81ed9f395d8ec36a2a70"
 
 [[package]]
 name = "libc"
-version = "0.2.125"
+version = "0.2.132"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5916d2ae698f6de9bfb891ad7a8d65c09d232dc58cc4ac433c7da3b2fd84bc2b"
+checksum = "8371e4e5341c3a96db127eb2465ac681ced4c433e01dd0e938adbef26ba93ba5"
 
 [[package]]
 name = "libgit2-sys"
@@ -2993,7 +3014,7 @@ dependencies = [
  "socket2 0.4.4",
  "tempfile",
  "thiserror",
- "time 0.3.9",
+ "time",
  "tokio",
  "toml",
  "tracing",
@@ -5838,16 +5859,6 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.1.43"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
-dependencies = [
- "libc",
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "time"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2702e08a7a860f005826c6815dcac101b19b5eb330c27fe4a5928fec1d20ddd"
@@ -6260,9 +6271,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.80"
+version = "0.2.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27370197c907c55e3f1a9fbe26f44e937fe6451368324e009cba39e139dc08ad"
+checksum = "7c53b543413a17a202f4be280a7e5c62a1c69345f5de525ee64f8cfdbc954994"
 dependencies = [
  "cfg-if 1.0.0",
  "wasm-bindgen-macro",
@@ -6270,9 +6281,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.80"
+version = "0.2.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53e04185bfa3a779273da532f5025e33398409573f348985af9a1cbf3774d3f4"
+checksum = "5491a68ab4500fa6b4d726bd67408630c3dbe9c4fe7bda16d5c82a1fd8c7340a"
 dependencies = [
  "bumpalo",
  "lazy_static",
@@ -6297,9 +6308,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.80"
+version = "0.2.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17cae7ff784d7e83a2fe7611cfe766ecf034111b49deb850a3dc7699c08251f5"
+checksum = "c441e177922bc58f1e12c022624b6216378e5febc2f0533e41ba443d505b80aa"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -6307,9 +6318,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.80"
+version = "0.2.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99ec0dc7a4756fffc231aab1b9f2f578d23cd391390ab27f952ae0c9b3ece20b"
+checksum = "7d94ac45fcf608c1f45ef53e748d35660f168490c10b23704c7779ab8f5c3048"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6320,9 +6331,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.80"
+version = "0.2.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d554b7f530dee5964d9a9468d95c1f8b8acae4f282807e7d27d4b03099a46744"
+checksum = "6a89911bd99e5f3659ec4acf9c4d93b0a90fe4a2a11f15328472058edc5261be"
 
 [[package]]
 name = "wasm-timer"

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -14,7 +14,7 @@ automerge = "0.1"
 anyhow = "1.0"
 base64 = "0.13"
 byteorder = "1.4"
-chrono = "0.4"
+chrono = { version = "0.4", default-features = false, features = ["clock", "std"] }
 either = { version = "1.6" }
 futures-lite = { version = "1.12" }
 git-trailers = "0.1.0"

--- a/inspect/Cargo.toml
+++ b/inspect/Cargo.toml
@@ -14,4 +14,4 @@ radicle-terminal = { path = "../terminal" }
 radicle-common = { path = "../common" }
 serde_json = "1.0"
 json-color = "0.7"
-chrono = "0.4"
+chrono = { version = "0.4", default-features = false, features = ["clock", "std"] }


### PR DESCRIPTION
Signed-off-by: Miss M <MissM_signed@protonmail.ch>

This PR resolves two below security advisories:

[RUSTSEC-2020-0159](RUSTSEC-2020-0159), [RUSTSEC-2020-0071](https://rustsec.org/advisories/RUSTSEC-2020-0071) - When doing env & time same time - it's not thread safe

Chrono from 0.4.20 has a new maintainer and did a lot of fixes including RiR localtime_r :partying_face: 

time 0.1 in turn is brought by chrono "oldtime" feature that is "optional" (but default) chrono dependency

`default = ["clock", "std", "oldtime", "wasmbind"]` -> `oldtime = ["time"]`

But time 0.1 was included via common & inspect as chrono was imported with default features

I've set the features explicitly leaving out `oldtime` that is not considered thread safe and `wasmbind` we don't need either

By specifying the feature explicitly we got rid of time 0.1 :partying_face: 

Then I had also - in order to bump the .lock more precisely for chrono 0.4.22 do:

$ cargo update -p chrono
```
    Updating crates.io index
    Updating chrono v0.4.19 -> v0.4.20
```

libc was holding back chrono bump to 0.4.22 so:

$ cargo update -p libc
```
    Updating crates.io index
    Updating libc v0.2.125 -> v0.2.132
```

$ cargo update -p chrono --precise 0.4.22
```
    Updating crates.io index
      Adding android_system_properties v0.1.4
    Updating chrono v0.4.20 -> v0.4.22
      Adding iana-time-zone v0.1.46
    Updating js-sys v0.3.57 -> v0.3.58
    Updating wasm-bindgen v0.2.80 -> v0.2.81
    Updating wasm-bindgen-backend v0.2.80 -> v0.2.81
    Updating wasm-bindgen-macro v0.2.80 -> v0.2.81
    Updating wasm-bindgen-macro-support v0.2.80 -> v0.2.81
    Updating wasm-bindgen-shared v0.2.80 -> v0.2.81
```

