### PR TITLE
Tell homebrew to auto update the Radicle tap

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,5 +43,5 @@ Then update the package list and install `radicle-cli`:
 
 ### 🍺 From Homebrew (x86_64)
 
-    brew tap radicle/cli https://seed.alt-clients.radicle.xyz/radicle-cli-homebrew.git
+    brew tap --force-auto-update radicle/cli https://seed.alt-clients.radicle.xyz/radicle-cli-homebrew.git
     brew install radicle-cli


### PR DESCRIPTION
As per [Homebrew docs](https://docs.brew.sh/Taps):
> Any location and any protocol that Git can handle is fine, although non-GitHub taps require running brew tap --force-auto-update <user/repo> to enable automatic updating.
