### PR TITLE
clone: reduce number of local branches

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -772,7 +772,7 @@ dependencies = [
 [[package]]
 name = "cob"
 version = "0.1.0"
-source = "git+https://github.com/radicle-dev/radicle-link?tag=cycle/2022-07-12#541a8161cb24c3b7b10d44f958cc5c5ed05cf443"
+source = "git+https://github.com/radicle-dev/radicle-link?tag=cycle/2022-09-06#99f42551d77addc8eb5a5db3f6538ceb853ff084"
 dependencies = [
  "either",
  "git-trailers",
@@ -1891,9 +1891,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.21"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3083ce4b914124575708913bca19bfe887522d6e2e6d0952943f5eac4a74010"
+checksum = "30bdd20c28fadd505d0fd6712cdfcb0d4b5648baf45faef7f852afb2399bb050"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1901,9 +1901,9 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.21"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c09fd04b7e4073ac7156a9539b57a484a8ea920f79c7c675d05d289ab6110d3"
+checksum = "4e5aa3de05362c3fb88de6531e6296e85cde7739cccad4b9dfeeb7f6ebce56bf"
 
 [[package]]
 name = "futures-executor"
@@ -1918,9 +1918,9 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.21"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc4045962a5a5e935ee2fdedaa4e08284547402885ab326734432bed5d12966b"
+checksum = "bbf4d2a7a308fd4578637c0b17c7e1c7ba127b8f6ba00b29f717e9655d85eb68"
 
 [[package]]
 name = "futures-lite"
@@ -1939,9 +1939,9 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.21"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33c1e13800337f4d4d7a316bf45a567dbcb6ffe087f16424852d97e97a91f512"
+checksum = "42cd15d1c7456c04dbdf7e88bcd69760d74f3a798d6444e16974b505b0e62f17"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1950,15 +1950,15 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.21"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21163e139fa306126e6eedaf49ecdb4588f939600f0b1e770f4205ee4b7fa868"
+checksum = "21b20ba5a92e727ba30e72834706623d94ac93a725410b6a6b6fbc1b07f7ba56"
 
 [[package]]
 name = "futures-task"
-version = "0.3.21"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57c66a976bf5909d801bbef33416c41372779507e7a6b3a5e25e4749c58f776a"
+checksum = "a6508c467c73851293f390476d4491cf4d227dbabcd4170f3bb6044959b294f1"
 
 [[package]]
 name = "futures-timer"
@@ -1968,9 +1968,9 @@ checksum = "e64b03909df88034c26dc1547e8970b91f98bdb65165d6a4e9110d94263dbb2c"
 
 [[package]]
 name = "futures-util"
-version = "0.3.21"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8b7abd5d659d9b90c8cba917f6ec750a74e2dc23902ef9cd4cc8c8b22e6036a"
+checksum = "44fb6cb1be61cc1d2e43b262516aafcf63b241cffdb1d3fa115f91d9c7b09c90"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -2224,7 +2224,7 @@ dependencies = [
 [[package]]
 name = "git-ref-format"
 version = "0.1.0"
-source = "git+https://github.com/radicle-dev/radicle-link?tag=cycle/2022-07-12#541a8161cb24c3b7b10d44f958cc5c5ed05cf443"
+source = "git+https://github.com/radicle-dev/radicle-link?tag=cycle/2022-09-06#99f42551d77addc8eb5a5db3f6538ceb853ff084"
 dependencies = [
  "git-ref-format-core",
  "git-ref-format-macro",
@@ -2233,7 +2233,7 @@ dependencies = [
 [[package]]
 name = "git-ref-format-core"
 version = "0.1.0"
-source = "git+https://github.com/radicle-dev/radicle-link?tag=cycle/2022-07-12#541a8161cb24c3b7b10d44f958cc5c5ed05cf443"
+source = "git+https://github.com/radicle-dev/radicle-link?tag=cycle/2022-09-06#99f42551d77addc8eb5a5db3f6538ceb853ff084"
 dependencies = [
  "bstr",
  "minicbor",
@@ -2244,7 +2244,7 @@ dependencies = [
 [[package]]
 name = "git-ref-format-macro"
 version = "0.1.0"
-source = "git+https://github.com/radicle-dev/radicle-link?tag=cycle/2022-07-12#541a8161cb24c3b7b10d44f958cc5c5ed05cf443"
+source = "git+https://github.com/radicle-dev/radicle-link?tag=cycle/2022-09-06#99f42551d77addc8eb5a5db3f6538ceb853ff084"
 dependencies = [
  "git-ref-format-core",
  "proc-macro-error",
@@ -2269,7 +2269,7 @@ dependencies = [
 [[package]]
 name = "git-trailers"
 version = "0.1.0"
-source = "git+https://github.com/radicle-dev/radicle-link?tag=cycle/2022-07-12#541a8161cb24c3b7b10d44f958cc5c5ed05cf443"
+source = "git+https://github.com/radicle-dev/radicle-link?tag=cycle/2022-09-06#99f42551d77addc8eb5a5db3f6538ceb853ff084"
 dependencies = [
  "nom 7.1.1",
  "thiserror",
@@ -2947,7 +2947,7 @@ dependencies = [
 [[package]]
 name = "librad"
 version = "0.1.0"
-source = "git+https://github.com/radicle-dev/radicle-link?tag=cycle/2022-07-12#541a8161cb24c3b7b10d44f958cc5c5ed05cf443"
+source = "git+https://github.com/radicle-dev/radicle-link?tag=cycle/2022-09-06#99f42551d77addc8eb5a5db3f6538ceb853ff084"
 dependencies = [
  "async-lock",
  "async-stream",
@@ -3053,7 +3053,7 @@ dependencies = [
 [[package]]
 name = "link-async"
 version = "0.1.0"
-source = "git+https://github.com/radicle-dev/radicle-link?tag=cycle/2022-07-12#541a8161cb24c3b7b10d44f958cc5c5ed05cf443"
+source = "git+https://github.com/radicle-dev/radicle-link?tag=cycle/2022-09-06#99f42551d77addc8eb5a5db3f6538ceb853ff084"
 dependencies = [
  "blocking",
  "futures",
@@ -3068,7 +3068,7 @@ dependencies = [
 [[package]]
 name = "link-canonical"
 version = "0.1.0"
-source = "git+https://github.com/radicle-dev/radicle-link?tag=cycle/2022-07-12#541a8161cb24c3b7b10d44f958cc5c5ed05cf443"
+source = "git+https://github.com/radicle-dev/radicle-link?tag=cycle/2022-09-06#99f42551d77addc8eb5a5db3f6538ceb853ff084"
 dependencies = [
  "link-canonical-derive",
  "nom 7.1.1",
@@ -3082,7 +3082,7 @@ dependencies = [
 [[package]]
 name = "link-canonical-derive"
 version = "0.1.0"
-source = "git+https://github.com/radicle-dev/radicle-link?tag=cycle/2022-07-12#541a8161cb24c3b7b10d44f958cc5c5ed05cf443"
+source = "git+https://github.com/radicle-dev/radicle-link?tag=cycle/2022-09-06#99f42551d77addc8eb5a5db3f6538ceb853ff084"
 dependencies = [
  "convert_case",
  "proc-macro2",
@@ -3093,7 +3093,7 @@ dependencies = [
 [[package]]
 name = "link-crypto"
 version = "0.1.0"
-source = "git+https://github.com/radicle-dev/radicle-link?tag=cycle/2022-07-12#541a8161cb24c3b7b10d44f958cc5c5ed05cf443"
+source = "git+https://github.com/radicle-dev/radicle-link?tag=cycle/2022-09-06#99f42551d77addc8eb5a5db3f6538ceb853ff084"
 dependencies = [
  "async-trait",
  "dyn-clone",
@@ -3116,7 +3116,7 @@ dependencies = [
 [[package]]
 name = "link-git"
 version = "0.1.0"
-source = "git+https://github.com/radicle-dev/radicle-link?tag=cycle/2022-07-12#541a8161cb24c3b7b10d44f958cc5c5ed05cf443"
+source = "git+https://github.com/radicle-dev/radicle-link?tag=cycle/2022-09-06#99f42551d77addc8eb5a5db3f6538ceb853ff084"
 dependencies = [
  "arc-swap",
  "async-process",
@@ -3153,7 +3153,7 @@ dependencies = [
 [[package]]
 name = "link-hooks"
 version = "0.1.0"
-source = "git+https://github.com/radicle-dev/radicle-link?tag=cycle/2022-07-12#541a8161cb24c3b7b10d44f958cc5c5ed05cf443"
+source = "git+https://github.com/radicle-dev/radicle-link?tag=cycle/2022-09-06#99f42551d77addc8eb5a5db3f6538ceb853ff084"
 dependencies = [
  "async-trait",
  "futures",
@@ -3168,7 +3168,7 @@ dependencies = [
 [[package]]
 name = "link-identities"
 version = "0.1.0"
-source = "git+https://github.com/radicle-dev/radicle-link?tag=cycle/2022-07-12#541a8161cb24c3b7b10d44f958cc5c5ed05cf443"
+source = "git+https://github.com/radicle-dev/radicle-link?tag=cycle/2022-09-06#99f42551d77addc8eb5a5db3f6538ceb853ff084"
 dependencies = [
  "either",
  "futures-lite",
@@ -3199,7 +3199,7 @@ dependencies = [
 [[package]]
 name = "link-replication"
 version = "0.1.0"
-source = "git+https://github.com/radicle-dev/radicle-link?tag=cycle/2022-07-12#541a8161cb24c3b7b10d44f958cc5c5ed05cf443"
+source = "git+https://github.com/radicle-dev/radicle-link?tag=cycle/2022-09-06#99f42551d77addc8eb5a5db3f6538ceb853ff084"
 dependencies = [
  "async-trait",
  "blocking",
@@ -3221,7 +3221,7 @@ dependencies = [
 [[package]]
 name = "link-tracking"
 version = "0.1.0"
-source = "git+https://github.com/radicle-dev/radicle-link?tag=cycle/2022-07-12#541a8161cb24c3b7b10d44f958cc5c5ed05cf443"
+source = "git+https://github.com/radicle-dev/radicle-link?tag=cycle/2022-09-06#99f42551d77addc8eb5a5db3f6538ceb853ff084"
 dependencies = [
  "cob",
  "either",
@@ -3244,7 +3244,7 @@ checksum = "7fb9b38af92608140b86b693604b9ffcc5824240a484d1ecd4795bacb2fe88f3"
 [[package]]
 name = "lnk-clib"
 version = "0.1.0"
-source = "git+https://github.com/radicle-dev/radicle-link?tag=cycle/2022-07-12#541a8161cb24c3b7b10d44f958cc5c5ed05cf443"
+source = "git+https://github.com/radicle-dev/radicle-link?tag=cycle/2022-09-06#99f42551d77addc8eb5a5db3f6538ceb853ff084"
 dependencies = [
  "async-trait",
  "futures",
@@ -3275,7 +3275,7 @@ dependencies = [
 [[package]]
 name = "lnk-identities"
 version = "0.1.0"
-source = "git+https://github.com/radicle-dev/radicle-link?tag=cycle/2022-07-12#541a8161cb24c3b7b10d44f958cc5c5ed05cf443"
+source = "git+https://github.com/radicle-dev/radicle-link?tag=cycle/2022-09-06#99f42551d77addc8eb5a5db3f6538ceb853ff084"
 dependencies = [
  "anyhow",
  "clap",
@@ -3301,7 +3301,7 @@ dependencies = [
 [[package]]
 name = "lnk-profile"
 version = "0.1.0"
-source = "git+https://github.com/radicle-dev/radicle-link?tag=cycle/2022-07-12#541a8161cb24c3b7b10d44f958cc5c5ed05cf443"
+source = "git+https://github.com/radicle-dev/radicle-link?tag=cycle/2022-09-06#99f42551d77addc8eb5a5db3f6538ceb853ff084"
 dependencies = [
  "anyhow",
  "clap",
@@ -3316,7 +3316,7 @@ dependencies = [
 [[package]]
 name = "lnk-sync"
 version = "0.1.0"
-source = "git+https://github.com/radicle-dev/radicle-link?tag=cycle/2022-07-12#541a8161cb24c3b7b10d44f958cc5c5ed05cf443"
+source = "git+https://github.com/radicle-dev/radicle-link?tag=cycle/2022-09-06#99f42551d77addc8eb5a5db3f6538ceb853ff084"
 dependencies = [
  "anyhow",
  "clap",
@@ -4818,7 +4818,7 @@ dependencies = [
 [[package]]
 name = "radicle-data"
 version = "0.1.0"
-source = "git+https://github.com/radicle-dev/radicle-link?tag=cycle/2022-07-12#541a8161cb24c3b7b10d44f958cc5c5ed05cf443"
+source = "git+https://github.com/radicle-dev/radicle-link?tag=cycle/2022-09-06#99f42551d77addc8eb5a5db3f6538ceb853ff084"
 dependencies = [
  "minicbor",
  "nonempty 0.7.0",
@@ -4830,7 +4830,7 @@ dependencies = [
 [[package]]
 name = "radicle-git-ext"
 version = "0.1.0"
-source = "git+https://github.com/radicle-dev/radicle-link?tag=cycle/2022-07-12#541a8161cb24c3b7b10d44f958cc5c5ed05cf443"
+source = "git+https://github.com/radicle-dev/radicle-link?tag=cycle/2022-09-06#99f42551d77addc8eb5a5db3f6538ceb853ff084"
 dependencies = [
  "git-ref-format",
  "git2",
@@ -4846,7 +4846,7 @@ dependencies = [
 [[package]]
 name = "radicle-git-helpers"
 version = "0.1.0"
-source = "git+https://github.com/radicle-dev/radicle-link?tag=cycle/2022-07-12#541a8161cb24c3b7b10d44f958cc5c5ed05cf443"
+source = "git+https://github.com/radicle-dev/radicle-link?tag=cycle/2022-09-06#99f42551d77addc8eb5a5db3f6538ceb853ff084"
 dependencies = [
  "anyhow",
  "git2",
@@ -4882,7 +4882,7 @@ dependencies = [
 [[package]]
 name = "radicle-macros"
 version = "0.1.0"
-source = "git+https://github.com/radicle-dev/radicle-link?tag=cycle/2022-07-12#541a8161cb24c3b7b10d44f958cc5c5ed05cf443"
+source = "git+https://github.com/radicle-dev/radicle-link?tag=cycle/2022-09-06#99f42551d77addc8eb5a5db3f6538ceb853ff084"
 dependencies = [
  "proc-macro-error",
  "quote",
@@ -4893,7 +4893,7 @@ dependencies = [
 [[package]]
 name = "radicle-std-ext"
 version = "0.1.0"
-source = "git+https://github.com/radicle-dev/radicle-link?tag=cycle/2022-07-12#541a8161cb24c3b7b10d44f958cc5c5ed05cf443"
+source = "git+https://github.com/radicle-dev/radicle-link?tag=cycle/2022-09-06#99f42551d77addc8eb5a5db3f6538ceb853ff084"
 
 [[package]]
 name = "radicle-terminal"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,55 +42,55 @@ members = [
 
 [patch.crates-io.link-crypto]
 git = "https://github.com/radicle-dev/radicle-link"
-tag = "cycle/2022-07-12"
+tag = "cycle/2022-09-06"
 
 [patch.crates-io.link-identities]
 git = "https://github.com/radicle-dev/radicle-link"
-tag = "cycle/2022-07-12"
+tag = "cycle/2022-09-06"
 
 [patch.crates-io.link-async]
 git = "https://github.com/radicle-dev/radicle-link"
-tag = "cycle/2022-07-12"
+tag = "cycle/2022-09-06"
 
 [patch.crates-io.link-replication]
 git = "https://github.com/radicle-dev/radicle-link"
-tag = "cycle/2022-07-12"
+tag = "cycle/2022-09-06"
 
 [patch.crates-io.radicle-git-helpers]
 git = "https://github.com/radicle-dev/radicle-link"
-tag = "cycle/2022-07-12"
+tag = "cycle/2022-09-06"
 
 [patch.crates-io.librad]
 git = "https://github.com/radicle-dev/radicle-link"
-tag = "cycle/2022-07-12"
+tag = "cycle/2022-09-06"
 
 [patch.crates-io.lnk-sync]
 git = "https://github.com/radicle-dev/radicle-link"
-tag = "cycle/2022-07-12"
+tag = "cycle/2022-09-06"
 
 [patch.crates-io.lnk-clib]
 git = "https://github.com/radicle-dev/radicle-link"
-tag = "cycle/2022-07-12"
+tag = "cycle/2022-09-06"
 
 [patch.crates-io.lnk-profile]
 git = "https://github.com/radicle-dev/radicle-link"
-tag = "cycle/2022-07-12"
+tag = "cycle/2022-09-06"
 
 [patch.crates-io.radicle-git-ext]
 git = "https://github.com/radicle-dev/radicle-link"
-tag = "cycle/2022-07-12"
+tag = "cycle/2022-09-06"
 
 [patch.crates-io.git-trailers]
 git = "https://github.com/radicle-dev/radicle-link"
-tag = "cycle/2022-07-12"
+tag = "cycle/2022-09-06"
 
 [patch.crates-io.git-ref-format]
 git = "https://github.com/radicle-dev/radicle-link"
-tag = "cycle/2022-07-12"
+tag = "cycle/2022-09-06"
 
 [patch.crates-io.lnk-identities]
 git = "https://github.com/radicle-dev/radicle-link"
-tag = "cycle/2022-07-12"
+tag = "cycle/2022-09-06"
 
 [patch.crates-io.automerge]
 git = "https://github.com/automerge/automerge-rs"


### PR DESCRIPTION
Avoid creating local branch references for tracking branches.  They are redundant, being already represented by the remote tracking branches.

Recent changes to radicle-link add the improvement.  The 'future's dependencies must be updated to the update.