### PR TITLE
Add vendored openssl, libgit2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3837,16 +3837,28 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "openssl"
-version = "0.10.38"
+version = "0.10.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c7ae222234c30df141154f159066c5093ff73b63204dcda7121eb082fc56a95"
+checksum = "618febf65336490dfcf20b73f885f5651a0c89c64c2d4a8c3662585a70bf5bd0"
 dependencies = [
  "bitflags",
  "cfg-if 1.0.0",
  "foreign-types",
  "libc",
  "once_cell",
+ "openssl-macros",
  "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b501e44f11665960c7e7fcf062c7d96a14ade4aa98116c004b2e37b5be7d736c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -3856,14 +3868,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
-name = "openssl-sys"
-version = "0.9.72"
+name = "openssl-src"
+version = "111.22.0+1.1.1q"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e46109c383602735fa0a2e48dd2b7c892b048e1bf69e5c3b1d804b7d9c203cb"
+checksum = "8f31f0d509d1c1ae9cada2f9539ff8f37933831fd5098879e482aa687d659853"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.75"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5f9bd0c2710541a3cda73d6f9ac4f1b240de4ae261065d309dbe73d9dceb42f"
 dependencies = [
  "autocfg",
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -18,7 +18,7 @@ chrono = { version = "0.4", default-features = false, features = ["clock", "std"
 either = { version = "1.6" }
 futures-lite = { version = "1.12" }
 git-trailers = "0.1.0"
-git2 = { version = "0.13", default-features = false, features = ["https"] }
+git2 = { version = "0.13", default-features = false, features = ["https", "vendored-openssl", "vendored-libgit2"] }
 lazy_static = "1.4.0"
 serde_json = "1.0"
 serde = "1.0"


### PR DESCRIPTION
Signed-off-by: pinkforest <36498018+pinkforest@users.noreply.github.com>

Closes #218  - Can open another issue to get rid of the git2 OpenSSL dependency completely

This changes to vendored latest OpenSSL and libgit2 via git2 dependency

## Vendored OpenSSL

By default when building something that brings openssl-sys, the underlying OpenSSL C-library is detected by way of opportunistic detection from system where ever it is built from source - whether static .a or dynamic .so object for the linker.

Unless certain rather fickly manual environment variables have been set - it's been derived from the system the thing is built in -

**For the user-built binaries from source**

These OpenSSL libraries in the underlying build system can be out of date - if they are installed that is - and it can be pure luck if the OpenSSL dep was up-to-date at build time at all.

**For the release binaries -** 

Since it's been complied statically - some time ago - there is no way to know what exact version of openssl was used unless the environment variables have been used in the build.

**Benefits of Vendored OpenSSL**

This changes to use the vendored feature for both libgit2 and openssl so it picks up what ever is in the .lock and we know exactly - via the openssl-src crate - what version it was built with given release from .lock that now includes openssl-src.

And this will be same for everyone instead of relying on luck what ever system had present at the build time.

**Existing downside of statically linked binary**

Downside with statically built OpenSSL (whether vendored or not) is that the whole binary must be re-built *when* the underlying OpenSSL C-Library has security vulnerabilities - thus is the reason I recommend in this order:

 - Try to get rid of OpenSSL dependency
 - Dynamic linking in OS'es it is present / in build targets where it typically is (e.g. not macos) or
 - Update mechanic that updates the binaries when openssl-src has new vulns

**We are better off in any case...**

Anyways we are better off since the openssl-src can be set - via vendoring - to drag in non-opportunistically the latest patched OpenSSL instead of the current opportunistic detection mechanism via openssl-sys that users currently end up using.

## Cross-building easier

This also makes cross-targets possible / easier since openssl-src works well with cross-build targets

As to size of auditable binary:

17M rad-x86_64-unknown-linux-gnu.bin

$ ldd rad-x86_64-unknown-linux-gnu.bin
```
  linux-vdso.so.1 (0x00007ffca3058000)
  libgcc_s.so.1 => /lib/x86_64-linux-gnu/libgcc_s.so.1 (0x00007fd7999f3000)
  libpthread.so.0 => /lib/x86_64-linux-gnu/libpthread.so.0 (0x00007fd7999d0000)
  libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x00007fd799881000)
  libdl.so.2 => /lib/x86_64-linux-gnu/libdl.so.2 (0x00007fd79987b000)
  libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007fd799689000)
  /lib64/ld-linux-x86-64.so.2 (0x00007fd79aa5a000)
```
For linux-gnu targets it is advisable to dynamically link above

## Cargo.lock changes

$ git diff Cargo.lock
```
diff --git a/Cargo.lock b/Cargo.lock
index 6f34a8f..47a4198 100644
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3855,6 +3855,15 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"

+[[package]]
+name = "openssl-src"
+version = "111.22.0+1.1.1q"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f31f0d509d1c1ae9cada2f9539ff8f37933831fd5098879e482aa687d659853"
+dependencies = [
+ "cc",
+]
+
 [[package]]
 name = "openssl-sys"
 version = "0.9.72"
@@ -3864,6 +3873,7 @@ dependencies = [
  "autocfg",
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]
```

Also we should bump openssl, openssl-sys

$ cargo update -p openssl-sys
```
    Updating crates.io index
    Updating openssl-sys v0.9.72 -> v0.9.75
```

$ cargo update -p openssl
```
    Updating crates.io index
    Updating openssl v0.10.38 -> v0.10.41
      Adding openssl-macros v0.1.0
```