### PR TITLE
rm: Remove profile with peer id

### DIFF
--- a/rm/src/lib.rs
+++ b/rm/src/lib.rs
@@ -6,9 +6,9 @@ use std::str::FromStr;
 use anyhow::anyhow;
 
 use librad::git::Urn;
+use librad::PeerId;
 
 use radicle_common::args::{Args, Error, Help};
-use radicle_common::profile::ProfileId;
 use radicle_common::{keys, profile, project};
 use radicle_terminal as term;
 
@@ -19,13 +19,13 @@ pub const HELP: Help = Help {
     usage: r#"
 Usage
 
-    rad rm <urn | profile-id> [<option>...]
+    rad rm <urn | peer-id> [<option>...]
 
 Options
 
     --no-confirm        Do not ask for confirmation before removal
                         (default: false)
-    --no-passphrase     If profile-id is given, bypass passphrase prompt and
+    --no-passphrase     If Peer ID is given, bypass passphrase prompt and
                         neither read environment variable `RAD_PASSPHRASE`
                         nor standard input stream (default: false)
     --stdin             Read passphrase from stdin (default: false)
@@ -35,7 +35,7 @@ Options
 
 enum Object {
     Project(Urn),
-    Profile(ProfileId),
+    User(PeerId),
     Unknown(String),
 }
 
@@ -43,8 +43,8 @@ impl From<&str> for Object {
     fn from(value: &str) -> Self {
         if let Ok(urn) = Urn::from_str(value) {
             Object::Project(urn)
-        } else if let Ok(id) = ProfileId::from_str(value) {
-            Object::Profile(id)
+        } else if let Ok(peer_id) = PeerId::from_str(value) {
+            Object::User(peer_id)
         } else {
             Object::Unknown(value.to_owned())
         }
@@ -94,7 +94,7 @@ impl Args for Options {
         Ok((
             Options {
                 object: object.ok_or_else(|| {
-                    anyhow!("Urn or profile id to remove must be provided; see `rad rm --help`")
+                    anyhow!("Urn or peer id to remove must be provided; see `rad rm --help`")
                 })?,
                 confirm,
                 passphrase,
@@ -108,10 +108,11 @@ impl Args for Options {
 pub fn run(options: Options, ctx: impl term::Context) -> anyhow::Result<()> {
     term::warning("Experimental tool; use at your own risk!");
 
+    let profile = ctx.profile()?;
+    let storage = profile::read_only(&profile)?;
+
     match &options.object {
         Object::Project(urn) => {
-            let profile = ctx.profile()?;
-            let storage = profile::read_only(&profile)?;
             let monorepo = profile.paths().git_dir();
 
             if project::get(&storage, urn)?.is_none() {
@@ -133,39 +134,46 @@ pub fn run(options: Options, ctx: impl term::Context) -> anyhow::Result<()> {
                 term::success!("Successfully removed project {}", &urn);
             }
         }
-        Object::Profile(id) => {
-            let profile = ctx.profile()?;
-            if profile.id() != id {
-                let profile = profile::get(id)?;
-                let read_only = profile::read_only(&profile)?;
-                let config = read_only.config()?;
-                let username = config.user_name()?;
-
-                if options.confirm
-                    && !term::confirm(format!(
-                        "Are you sure you would like to delete {} ({})?",
-                        term::format::dim(id),
-                        term::format::dim(username)
-                    ))
+        Object::User(peer_id) => {
+            let profiles = profile::list()?;
+            if storage.peer_id() != peer_id {
+                if let Some((storage, other)) = profiles
+                    .iter()
+                    .map(|p| (profile::read_only(p), p))
+                    .find(|(s, _)| match s {
+                        Ok(s) => s.peer_id() == peer_id,
+                        Err(_) => false,
+                    })
                 {
-                    return Ok(());
-                }
-
-                if options.passphrase {
-                    let passphrase = term::read_passphrase(options.stdin, false)?;
-                    if keys::load_secret_key(&profile, passphrase).is_err() {
-                        anyhow::bail!(format!("Invalid passphrase supplied."));
+                    let read_only = storage?;
+                    let config = read_only.config()?;
+                    let username = config.user_name()?;
+                    if options.confirm
+                        && !term::confirm(format!(
+                            "Are you sure you would like to remove {} ({})?",
+                            term::format::dim(peer_id),
+                            term::format::dim(username)
+                        ))
+                    {
+                        return Ok(());
                     }
+                    if options.passphrase {
+                        let passphrase = term::read_passphrase(options.stdin, false)?;
+                        if keys::load_secret_key(other, passphrase).is_err() {
+                            anyhow::bail!(format!("Invalid passphrase supplied."));
+                        }
+                    }
+                    profile::remove(other)?;
+                    term::success!("Successfully removed user {}", peer_id);
+                } else {
+                    anyhow::bail!("No user found with Peer ID: {}", peer_id);
                 }
-
-                profile::remove(&profile)?;
-                term::success!("Successfully removed profile {}", id);
             } else {
-                anyhow::bail!("Cannot remove active profile; see `rad auth --help`");
+                anyhow::bail!("Cannot remove active user; see `rad auth --help`");
             }
         }
         Object::Unknown(arg) => {
-            anyhow::bail!(format!("Object must be an Urn or a profile id: {}", arg));
+            anyhow::bail!(format!("Object must be an URN or a Peer ID: {}", arg));
         }
     }
 


### PR DESCRIPTION
### Motivation

The intended usage of `rad rm <urn | profile-id>` (in conjunction with `rad auth`) was a bit unclear as the concepts of profiles and identities require deeper technical knowledge.

With this PR `rad rm` needs to be called with a `peer-id` instead of a `profile-id`. This change is also inline with the upcoming protocol update that makes increased usage of Peer IDs.  

Some users got the internal error message `missing field 'subject'` when passing a URN that does not point to a project. This is now also handled more gracefully.